### PR TITLE
make inspection of reports possible

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/VelocityTemplateEngine.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/VelocityTemplateEngine.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.parser.node.SimpleNode;
 
 import fr.opensagres.xdocreport.core.EncodingConstants;
 import fr.opensagres.xdocreport.core.XDocReportException;
@@ -107,6 +108,16 @@ public class VelocityTemplateEngine
     {
         VelocityEngine velocityEngine = getVelocityEngine();
         velocityEngine.evaluate( (VelocityContext) context, writer, templateName, reader );
+    }
+
+    public SimpleNode parse(String templateName) throws XDocReportException {
+        VelocityEngine velocityEngine = getVelocityEngine();
+        Template template = velocityEngine.getTemplate( templateName, EncodingConstants.UTF_8.name() );
+        if ( template != null )
+        {
+        	return (SimpleNode)template.getData();
+        }
+    	return null;
     }
 
     protected synchronized VelocityEngine getVelocityEngine()


### PR DESCRIPTION
To check a report prior to it's usage it is necessary just to parse but
not to merge it. For this the velocity template enginges should provide a method just for parsing the report.