### PR TITLE
Feature/upgrade itext5

### DIFF
--- a/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/pom.xml
+++ b/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.7-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/pom.xml
+++ b/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.5.7-SNAPSHOT</version>
+			<version>5.5.7</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/src/main/java/fr/opensagres/xdocreport/itext/extension/ExtendedPdfContentByte.java
+++ b/thirdparties-extension/fr.opensagres.xdocreport.itext5.extension/src/main/java/fr/opensagres/xdocreport/itext/extension/ExtendedPdfContentByte.java
@@ -44,17 +44,17 @@ public class ExtendedPdfContentByte
     }
 
     @Override
-    public void addImage( Image image, float a, float b, float c, float d, float e, float f, boolean inlineImage )
+    public void addImage( Image image, double a, double b, double c, double d, double e, double f, boolean inlineImage, boolean isMCBlockOpened )
         throws DocumentException
     {
         if ( image instanceof ExtendedImage )
         {
             ExtendedImage extImg = (ExtendedImage) image;
-            super.addImage( extImg.getImage(), a, b, c, d, e, f + extImg.getOffsetY(), inlineImage );
+            super.addImage( extImg.getImage(), a, b, c, d, e, f + extImg.getOffsetY(), inlineImage, isMCBlockOpened );
         }
         else
         {
-            super.addImage( image, a, b, c, d, e, f, inlineImage );
+            super.addImage( image, a, b, c, d, e, f, inlineImage, isMCBlockOpened );
         }
     }
 }

--- a/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/pom.xml
+++ b/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.5.7-SNAPSHOT</version>
+			<version>5.5.7</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/pom.xml
+++ b/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.7-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/src/test/java/org/apache/poi/xwpf/converter/core/AbstractXWPFPOIConverterTest.java
+++ b/thirdparties-extension/org.apache.poi.xwpf.converter.pdf.itext5/src/test/java/org/apache/poi/xwpf/converter/core/AbstractXWPFPOIConverterTest.java
@@ -26,7 +26,6 @@ package org.apache.poi.xwpf.converter.core;
 
 import java.io.IOException;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public abstract class AbstractXWPFPOIConverterTest
@@ -54,7 +53,6 @@ public abstract class AbstractXWPFPOIConverterTest
     }
 
     @Test
-    @Ignore("not sure about the null pointer exception")
     public void CV()
         throws IOException
     {

--- a/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/pom.xml
+++ b/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.5.7-SNAPSHOT</version>
+			<version>5.5.7</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/pom.xml
+++ b/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>itextpdf</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.7-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/src/test/java/org/odftoolkit/odfdom/converter/core/AbstractODFDOMConverterTest.java
+++ b/thirdparties-extension/org.odftoolkit.odfdom.converter.pdf.itext5/src/test/java/org/odftoolkit/odfdom/converter/core/AbstractODFDOMConverterTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public abstract class AbstractODFDOMConverterTest
 {
     @Test
-    @Ignore("not sure about the NullPointerException")
+    @Ignore("AssertionError from iText because top left cell on new page is null")
     public void CV()
         throws Exception
     {


### PR DESCRIPTION
An upgrade to iText 5.5.7 for the itext5 plugin, as discussed earlier in #63 . This fixes a failing test, and opens the door for writing an ExtendedCompareTool for content comparison of PDF files, as discussed in #64 