### PR TITLE
make text color rendered when using addFieldAsTextStyling with syntax…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .classpath
 /target
 /.repository/
+.idea
+*.iml

--- a/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxDocumentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxDocumentHandler.java
@@ -61,11 +61,11 @@ public class DocxDocumentHandler
     private boolean underlining;
 
     private boolean striking;
-    
+
     private boolean subscripting;
 
     private boolean superscripting;
-    
+
     private Stack<ContainerProperties> paragraphsStack;
 
     private Stack<SpanProperties> spansStack;
@@ -231,6 +231,7 @@ public class DocxDocumentHandler
             boolean strike = striking;
             boolean subscript = subscripting;
             boolean superscript = superscripting;
+            String color = null;
             SpanProperties properties = getCurrentSpanProperties();
             if ( properties != null )
             {
@@ -259,17 +260,21 @@ public class DocxDocumentHandler
                 {
                 	superscript = properties.isSuperscript();
                 }
+                if (null == color)
+                {
+                  color = properties.getColor();
+                }
             }
             super.write( "<w:r>" );
             // w:RP
-            processRunProperties( false, bold, italic, underline, strike, subscript, superscript );
+            processRunProperties( false, bold, italic, underline, strike, subscript, superscript, color );
             // w:br
             for ( int i = 0; i < addLineBreak; i++ )
             {
                 super.write( "<w:br/>" );
             }
             addLineBreak = 0;
-            if(!content.isEmpty()) 
+            if(!content.isEmpty())
             {
 	            // w:t
 	            super.write( "<w:t xml:space=\"preserve\" >" );
@@ -281,16 +286,20 @@ public class DocxDocumentHandler
     }
 
     private void processRunProperties( boolean isInsidePPr, boolean bold, boolean italics, boolean underline,
-                                       boolean strike, boolean subscript, boolean superscript )
+                                       boolean strike, boolean subscript, boolean superscript, String color )
         throws IOException
     {
-        if ( bold || italics || underline || strike || subscript || superscript  )
+        if ( bold || italics || underline || strike || subscript || superscript || color != null )
         {
             if ( isInsidePPr )
             {
                 startPPrIfNeeded();
             }
             super.write( "<w:rPr>" );
+            if (color != null)
+            {
+                super.write("<w:color w:val=\""+ color +"\"/>");
+            }
             if ( bold )
             {
                 super.write( "<w:b />" );
@@ -408,7 +417,7 @@ public class DocxDocumentHandler
 
     /**
      * Generate wpPr docx element.
-     * 
+     *
      * @param properties
      * @param pStyle
      * @param isList
@@ -473,7 +482,7 @@ public class DocxDocumentHandler
             }
             // rPPr
             processRunProperties( true, properties.isBold(), properties.isItalic(), properties.isUnderline(),
-                                  properties.isStrike(), properties.isSubscript(), properties.isSuperscript() );
+                                  properties.isStrike(), properties.isSubscript(), properties.isSuperscript(), properties.getColor() );
         }
 
         endPPrIfNeeded();
@@ -563,7 +572,7 @@ public class DocxDocumentHandler
     protected void doStartOrderedList( ListProperties properties )
         throws IOException
     {
-    	if(this.addLineBreak>0) 
+    	if(this.addLineBreak>0)
     	{
     		handleString("");
     	}
@@ -583,7 +592,7 @@ public class DocxDocumentHandler
     protected void doStartUnorderedList( ListProperties properties )
         throws IOException
     {
-    	if(this.addLineBreak>0) 
+    	if(this.addLineBreak>0)
     	{
     		handleString("");
     	}

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelper.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelper.java
@@ -78,7 +78,7 @@ public class StylesHelper
 
     /**
      * Create {@link ParagraphProperties} from inline style.
-     * 
+     *
      * @param style
      * @return
      */
@@ -96,7 +96,7 @@ public class StylesHelper
 
     /**
      * Create {@link HeaderProperties} from inline style.
-     * 
+     *
      * @param style
      * @return
      */
@@ -114,7 +114,7 @@ public class StylesHelper
 
     /**
      * Create {@link ListItemProperties} from inline style.
-     * 
+     *
      * @param style
      * @return
      */
@@ -132,7 +132,7 @@ public class StylesHelper
 
     /**
      * Create {@link ListProperties} from inline style.
-     * 
+     *
      * @param style
      * @return
      */
@@ -150,7 +150,7 @@ public class StylesHelper
 
     /**
      * Create {@link SpanProperties} from inline style.
-     * 
+     *
      * @param style
      * @return
      */
@@ -204,6 +204,13 @@ public class StylesHelper
             }
         }
 
+        // color
+        String color = stylesMap.get( "color" );
+        if ( color != null )
+        {
+            properties.setColor(color);
+        }
+        
         // text-decoration
         String textDecoration = stylesMap.get( "text-decoration" );
         properties.setStrike( false );

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/ContainerProperties.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/ContainerProperties.java
@@ -57,6 +57,8 @@ public abstract class ContainerProperties
 
     private final ContainerType type;
 
+    private String color;
+
     public ContainerProperties( ContainerType type )
     {
         this.type = type;
@@ -65,6 +67,15 @@ public abstract class ContainerProperties
     public ContainerType getType()
     {
         return type;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public ContainerProperties setColor(String color) {
+        this.color = color;
+        return this;
     }
 
     public boolean isPageBreakBefore()


### PR DESCRIPTION
- There are 3 issue when I using xdocreport to export docx and convert docx to pdf with Velocity template
1: Use addFieldAsTextStyling with SyntaxKind.Html: color was ignored
  `<span style=\"color:#FF0000;\">Title</span>`
2: When using with velocity template to render anchor link in docx, then I convert to pdf, anchor link was converted but do not navigate to location when click on it.
3: Color from docx was ignored when convert to pdf with option: 
 `Options.getTo(ConverterTypeTo.PDF)
        .via(ConverterTypeVia.XWPF)`