### PR TITLE
Add option for XHTMLOptions to export image as base64 data

### DIFF
--- a/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/pom.xml
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/pom.xml
@@ -12,5 +12,10 @@
   		<artifactId>fr.opensagres.odfdom.converter.core</artifactId>
   		<version>2.0.1-SNAPSHOT</version>
   	</dependency>
+      <dependency>
+          <groupId>fr.opensagres.xdocreport</groupId>
+          <artifactId>fr.opensagres.xdocreport.core</artifactId>
+          <version>2.0.1-SNAPSHOT</version>
+      </dependency>
   </dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/odfdom/converter/internal/xhtml/ElementVisitorForXHTML.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/odfdom/converter/internal/xhtml/ElementVisitorForXHTML.java
@@ -29,11 +29,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import javax.activation.MimetypesFileTypeMap;
 
+import fr.opensagres.xdocreport.core.utils.Base64Utility;
 import org.odftoolkit.odfdom.doc.OdfDocument;
 import org.odftoolkit.odfdom.dom.element.OdfStylableElement;
 import org.odftoolkit.odfdom.dom.element.draw.DrawFrameElement;
@@ -482,7 +482,7 @@ public class ElementVisitorForXHTML
             StringBuilder src = new StringBuilder();
             src.append( DATA_ATTR_TAG );
             src.append( mimeType + ";base64,");
-            src.append( Base64.getEncoder().encodeToString( imageStream ) );
+            src.append( Base64Utility.encode( imageStream ) );
 
             attributes.add( SRC_ATTR );
             attributes.add( src.toString() );

--- a/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/odfdom/converter/xhtml/XHTMLOptions.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/odfdom/converter/xhtml/XHTMLOptions.java
@@ -37,6 +37,8 @@ public class XHTMLOptions
 
     private IURIResolver resolver = IURIResolver.DEFAULT;
 
+    private boolean exportImageAsBase64;
+
     private XHTMLOptions()
     {
     }
@@ -76,6 +78,14 @@ public class XHTMLOptions
     public XHTMLOptions URIResolver( IURIResolver resolver )
     {
         this.resolver = resolver;
+        return this;
+    }
+
+    public boolean getExportImageAsBase64() { return exportImageAsBase64; }
+
+    public XHTMLOptions exportImageAsBase64( boolean exportImageAsBase64 )
+    {
+        this.exportImageAsBase64 = exportImageAsBase64;
         return this;
     }
 }

--- a/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/xdocreport/xhtml/extension/XHTMLConstants.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/main/java/fr/opensagres/xdocreport/xhtml/extension/XHTMLConstants.java
@@ -85,4 +85,6 @@ public interface XHTMLConstants
     String STYLE_ATTR = "style";
 
     String DISPLAY_ATTR = "display";
+
+    String DATA_ATTR_TAG = "data:";
 }

--- a/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/test/java/org/odftoolkit/odfdom/converter/xhtml/XHTMLConverterTestCase.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.xhtml/src/test/java/org/odftoolkit/odfdom/converter/xhtml/XHTMLConverterTestCase.java
@@ -45,6 +45,7 @@ public class XHTMLConverterTestCase
     {
         doGenerateSysOut( fileInName );
         doGenerateHTMLFile( fileInName );
+        doGenerateHTMLFileInnerImage( fileInName );
     }
 
     protected void doGenerateSysOut( String fileInName )
@@ -64,10 +65,30 @@ public class XHTMLConverterTestCase
         System.out.println( "Elapsed time=" + ( System.currentTimeMillis() - startTime ) );
     }
 
+    protected void doGenerateHTMLFileInnerImage( String fileInName )
+            throws Exception
+    {
+        String fileOutName = "target/" + fileInName + "_inner_image.html";
+
+        long startTime = System.currentTimeMillis();
+
+        OdfTextDocument document =
+                OdfTextDocument.loadDocument( AbstractODFDOMConverterTest.class.getResourceAsStream( fileInName ) );
+        XHTMLOptions options = XHTMLOptions.create();
+        options.indent( 1 );
+        options.generateCSSComments( true );
+        options.exportImageAsBase64( true );
+
+        OutputStream out = new FileOutputStream( new File( fileOutName ) );
+        XHTMLConverter.getInstance().convert( document, out, options );
+
+        System.out.println( "Generate " + fileOutName + " with " + ( System.currentTimeMillis() - startTime ) + " ms." );
+
+    }
+
     protected void doGenerateHTMLFile( String fileInName )
         throws Exception
     {
-
         String root = "target";
         String fileOutName = root + "/" + fileInName + ".html";
 
@@ -78,6 +99,7 @@ public class XHTMLConverterTestCase
         XHTMLOptions options = XHTMLOptions.create();
         options.indent( 1 );
         options.generateCSSComments( true );
+        options.exportImageAsBase64( true );
         // Extract image
         File imageFolder = new File( root + "/images/" + fileInName );
         options.setExtractor( new FileImageExtractor( imageFolder ) );


### PR DESCRIPTION
Hello!
Add a option 'exportImageAsBase64' for XHTMLOptions., then the images in the ODT will export as base64 data in the HTML when convert ODT to HTML.
I think it is useful. 
Thinks.