### PR TITLE
add the simple implementations to embed image in html;

### DIFF
--- a/gae/fr.opensagres.poi.xwpf.converter.xhtml-gae/pom.xml
+++ b/gae/fr.opensagres.poi.xwpf.converter.xhtml-gae/pom.xml
@@ -42,5 +42,10 @@
 			<artifactId>fr.opensagres.poi.xwpf.converter.core-gae</artifactId>
 			<version>2.0.1-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>fr.opensagres.xdocreport.core</artifactId>
+			<version>2.0.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
@@ -24,5 +24,10 @@
 			<artifactId>ooxml-schemas</artifactId>
 			<version>1.3</version>
 		</dependency>
+        <dependency>
+            <groupId>fr.opensagres.xdocreport</groupId>
+            <artifactId>fr.opensagres.xdocreport.core</artifactId>
+            <version>2.0.1-SNAPSHOT</version>
+        </dependency>
 	</dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
@@ -24,10 +24,5 @@
 			<artifactId>ooxml-schemas</artifactId>
 			<version>1.3</version>
 		</dependency>
-        <dependency>
-            <groupId>fr.opensagres.xdocreport</groupId>
-            <artifactId>fr.opensagres.xdocreport.core</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
-        </dependency>
 	</dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/pom.xml
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/pom.xml
@@ -12,5 +12,10 @@
 			<artifactId>fr.opensagres.poi.xwpf.converter.core</artifactId>
 			<version>2.0.1-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>fr.opensagres.xdocreport</groupId>
+			<artifactId>fr.opensagres.xdocreport.core</artifactId>
+			<version>2.0.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/Base64EmbedImgManager.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/Base64EmbedImgManager.java
@@ -1,0 +1,34 @@
+package fr.opensagres.poi.xwpf.converter.xhtml;
+
+import fr.opensagres.poi.xwpf.converter.core.FileImageExtractor;
+import fr.opensagres.poi.xwpf.converter.core.IURIResolver;
+import fr.opensagres.xdocreport.core.utils.Base64Utility;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by zzt on 17/4/11.
+ */
+public class Base64EmbedImgManager extends FileImageExtractor implements IURIResolver {
+    private static final String EMBED_IMG_SRC_PREFIX = XHTMLConstants.DATA_ATTR + ";base64,";
+
+    private byte[] picture;
+
+    public Base64EmbedImgManager(String baseDir) {
+        super(new File(baseDir));
+    }
+
+    @Override
+    public void extract(String imagePath, byte[] imageData) throws IOException {
+        this.picture = imageData;
+    }
+
+    @Override
+    public String resolve(String uri) {
+        StringBuilder sb = new StringBuilder(picture.length + EMBED_IMG_SRC_PREFIX.length())
+                .append(EMBED_IMG_SRC_PREFIX)
+                .append(Base64Utility.encode(picture));
+        return sb.toString();
+    }
+}

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLConstants.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLConstants.java
@@ -60,4 +60,6 @@ public class XHTMLConstants
 
     public static final String SRC_ATTR = "src";
 
+    public static final String DATA_ATTR = "data:";
+
 }


### PR DESCRIPTION
Hi,
This the solution I used when I using your lib to convert docx to html and need to embed image into html. It take me some time to figure it out. But it has some flaws:

- can't specify MIME type, even though the browser still show the image
- can't easily manipulate image, like compress them

If you think this simple solution isn't enough, I may change the `XWPFDocumentVisitor` and change the extractor's interfaces.

Thanks.