### PR TITLE
combine the options of image src resolver and image extractor;

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ImageManager.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ImageManager.java
@@ -1,0 +1,42 @@
+package fr.opensagres.poi.xwpf.converter.core;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by zzt on 17/4/11.
+ */
+public class ImageManager extends FileImageExtractor implements IURIResolver {
+
+    private final String imageSubDir;
+
+    public ImageManager(File baseDir, String imageSubDir) {
+        super(baseDir);
+        this.imageSubDir = imageSubDir;
+    }
+
+    @Override
+    public void extract(String imagePath, byte[] imageData) throws IOException {
+        super.extract(getImageRelativePath(imagePath), imageData);
+    }
+
+    /**
+     * using customized image directory to replace fixed {@link XWPFDocumentVisitor#WORD_MEDIA}
+     *
+     * @param imagePath image name with path
+     * @return the path relative the original {@link #baseDir}
+     */
+    private String getImageRelativePath(String imagePath) {
+        return new File(imageSubDir, getFileName(imagePath)).toString();
+    }
+
+    private String getFileName(String imagePath) {
+        return new File(imagePath).getName();
+    }
+
+    @Override
+    public String resolve(String uri) {
+        return getImageRelativePath(uri);
+    }
+
+}

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/Options.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/Options.java
@@ -34,7 +34,7 @@ public class Options
      * 
      * @param extractor image extractor.
      */
-    public void setExtractor( IImageExtractor extractor )
+    protected void setExtractor( IImageExtractor extractor )
     {
         this.extractor = extractor;
     }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLOptions.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLOptions.java
@@ -25,6 +25,7 @@
 package fr.opensagres.poi.xwpf.converter.xhtml;
 
 import fr.opensagres.poi.xwpf.converter.core.IURIResolver;
+import fr.opensagres.poi.xwpf.converter.core.ImageManager;
 import fr.opensagres.poi.xwpf.converter.core.Options;
 
 public class XHTMLOptions
@@ -80,9 +81,16 @@ public class XHTMLOptions
         return resolver;
     }
 
+    @Deprecated
     public XHTMLOptions URIResolver( IURIResolver resolver )
     {
         this.resolver = resolver;
+        return this;
+    }
+
+    public XHTMLOptions setImageManager( ImageManager imageManager ) {
+        this.resolver = imageManager;
+        setExtractor(imageManager);
         return this;
     }
 

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/test/java/org/apache/poi/xwpf/converter/xhtml/XHTMLConverterChineseTestCase.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/test/java/org/apache/poi/xwpf/converter/xhtml/XHTMLConverterChineseTestCase.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import fr.opensagres.poi.xwpf.converter.core.ImageManager;
 import org.apache.poi.xwpf.converter.core.AbstractXWPFPOIConverterTest;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.junit.Test;
@@ -84,11 +85,8 @@ public class XHTMLConverterChineseTestCase
 
         XHTMLOptions options = XHTMLOptions.create().indent( 4 );
         // Extract image
-        File imageFolder = new File( root + "/images/" + fileInName );
-        options.setExtractor( new FileImageExtractor( imageFolder ) );
-        // URI resolver
-        options.URIResolver( new FileURIResolver( imageFolder ) );
-        
+        options.setImageManager( new ImageManager( new File(root), "images" ) );
+
         File outFile = new File( fileOutName );
         outFile.getParentFile().mkdirs();
         OutputStream out = new FileOutputStream( outFile );

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/test/java/org/apache/poi/xwpf/converter/xhtml/XHTMLConverterTestCase.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/test/java/org/apache/poi/xwpf/converter/xhtml/XHTMLConverterTestCase.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import fr.opensagres.poi.xwpf.converter.core.ImageManager;
 import org.apache.poi.xwpf.converter.core.AbstractXWPFPOIConverterTest;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
@@ -76,10 +77,7 @@ public class XHTMLConverterTestCase
 
         XHTMLOptions options = XHTMLOptions.create();// .indent( 4 );
         // Extract image
-        File imageFolder = new File( root + "/images/" + fileInName );
-        options.setExtractor( new FileImageExtractor( imageFolder ) );
-        // URI resolver
-        options.URIResolver( new FileURIResolver( imageFolder ) );
+        options.setImageManager( new ImageManager( new File(root), "images" ) );
 
         OutputStream out = new FileOutputStream( new File( fileOutName ) );
         XHTMLConverter.getInstance().convert( document, out, options );


### PR DESCRIPTION
Hi,

When I use your lib, it takes me some time to understand the functionality of `resolver`, which for conversion of html, resolve the image's src attribute. As far as I understand, the resolver and image extractor can be combined for XHTML, which is easier to understand and write.

So I use one method/class to replace two:

- make `URIResolver` deprecated
- make `setExtractor` protected -- may affect the pdf conversion, but I didn't find any usage for pdf conversion in project
- add `setImageManager`

Thanks.
