### PR TITLE
Fix recursive lookup of dotted keys.

### DIFF
--- a/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/internal/DynamicBean.java
+++ b/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/internal/DynamicBean.java
@@ -51,7 +51,7 @@ public class DynamicBean
             }
             else
             {
-                bean = getDynamicBean( key );
+                bean = bean.getDynamicBean( key );
             }
         }
     }


### PR DESCRIPTION
When evaluating a dotted key, the next segment should always be evaluated based on the previous, but now it's always done on the root. E.g. "A.B.C" is evaluated as "A.C". This PR fixes this.