### PR TITLE
Fix introspector class blacklisting in velocity config

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/resources/xdocreport-velocity.properties
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/resources/xdocreport-velocity.properties
@@ -280,24 +280,9 @@ runtime.introspector.uberspect = org.apache.velocity.util.introspection.Uberspec
 
 introspector.restrict.packages = java.lang.reflect
 
-# The two most dangerous classes
+# The most dangerous classes
 
-introspector.restrict.classes = java.lang.Class
-introspector.restrict.classes = java.lang.ClassLoader
-                
-# Restrict these for extra safety
-
-introspector.restrict.classes = java.lang.Compiler
-introspector.restrict.classes = java.lang.InheritableThreadLocal
-introspector.restrict.classes = java.lang.Package
-introspector.restrict.classes = java.lang.Process
-introspector.restrict.classes = java.lang.Runtime
-introspector.restrict.classes = java.lang.RuntimePermission
-introspector.restrict.classes = java.lang.SecurityManager
-introspector.restrict.classes = java.lang.System
-introspector.restrict.classes = java.lang.Thread
-introspector.restrict.classes = java.lang.ThreadGroup
-introspector.restrict.classes = java.lang.ThreadLocal
+introspector.restrict.classes = java.lang.Class, java.lang.ClassLoader, java.lang.Compiler, java.lang.InheritableThreadLocal, java.lang.Package, java.lang.Process, java.lang.Runtime, java.lang.RuntimePermission, java.lang.SecurityManager, java.lang.System, java.lang.Thread, java.lang.ThreadGroup, java.lang.ThreadLocal
 
 
 ### XDOCREPORT velocity config


### PR DESCRIPTION
Before this patch, the `introspector.restrict.classes` property appeared multiple times in the config file and the behaviour in this case is to take the value of the last occurence of the property.

With my patch, all the classes in this list are now blacklisted by velocity.