### PR TITLE
Issue #245: HTML Text Styling is not retaining source font size and formatting

### DIFF
--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTReport.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTReport.java
@@ -29,8 +29,13 @@ import static fr.opensagres.xdocreport.document.odt.ODTConstants.METAINF_MANIFES
 import static fr.opensagres.xdocreport.document.odt.ODTConstants.MIME_MAPPING;
 import static fr.opensagres.xdocreport.document.odt.ODTConstants.STYLES_XML_ENTRY;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
+import com.sun.org.apache.xml.internal.serialize.OutputFormat;
+import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 import fr.opensagres.xdocreport.converter.MimeMapping;
 import fr.opensagres.xdocreport.core.XDocReportException;
 import fr.opensagres.xdocreport.core.document.DocumentKind;
@@ -38,6 +43,7 @@ import fr.opensagres.xdocreport.core.io.IEntryOutputStreamProvider;
 import fr.opensagres.xdocreport.core.io.IEntryReaderProvider;
 import fr.opensagres.xdocreport.core.io.IEntryWriterProvider;
 import fr.opensagres.xdocreport.core.io.XDocArchive;
+import fr.opensagres.xdocreport.core.io.internal.ByteArrayOutputStream;
 import fr.opensagres.xdocreport.document.AbstractXDocReport;
 import fr.opensagres.xdocreport.document.images.IImageRegistry;
 import fr.opensagres.xdocreport.document.odt.images.ODTImageRegistry;
@@ -47,6 +53,14 @@ import fr.opensagres.xdocreport.document.odt.preprocessor.ODTStylesPreprocessor;
 import fr.opensagres.xdocreport.document.odt.template.ODTContextHelper;
 import fr.opensagres.xdocreport.document.odt.textstyling.ODTDefaultStyle;
 import fr.opensagres.xdocreport.template.IContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * Open Office ODT report. For mime mapping please see {@see
@@ -117,6 +131,140 @@ public class ODTReport
         // 3) Register styles generator if not exists.
         ODTContextHelper.getStylesGenerator( context ); 
 
+    }
+
+    @Override
+    protected void doPostprocessIfNeeded( XDocArchive outputArchive )
+        throws Exception
+    {
+        applyParentStyleToChildren(outputArchive);
+    }
+
+    /**
+     * Text styling will style the nodes with some generated style such as XDocReport_Bold. These styles inherit
+     * from the default paragraph styles so will ignore the style of the enclosing mail merge field. Another issue
+     * was that nested styles would not stack. For example <b>bold <i>italic</i></b> would look <b>bold</b> <i>italic</i>
+     * because unlike HTML and CSS, styling rules aren't inherited from enclosing tags.
+     *
+     * This post processing loops through each element in the document body and generate bespoke styles for each element
+     * with an XDocReport style. This new style will inherit from the parent style but copy all the style rules from the
+     * XDocReport style.
+     *
+     * @param outputArchive the output archive after processing the report. Any changes will be written back into this
+     *                      archive.
+     */
+    private static void applyParentStyleToChildren( XDocArchive outputArchive )
+        throws ParserConfigurationException, IOException, SAXException
+    {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder xmlDocBuilder = documentBuilderFactory.newDocumentBuilder();
+
+        // This is a document of the base styles for the document
+        Document styleXML= xmlDocBuilder
+          .parse(outputArchive.getEntryInputStream("styles.xml"));
+
+        // This document contains the text content as well as a number of "automatic" styles for each element. We generate
+        // a new automatic style for each text node with a XDocReport style.
+        Document contentXML = xmlDocBuilder
+          .parse(outputArchive.getEntryInputStream("content.xml"));
+
+
+        // recursively apply the parent styles to child nodes
+        applyParentStyleToChildren(contentXML, styleXML);
+
+        // write the changes back into the archive
+        ByteArrayOutputStream contentOutStream = new ByteArrayOutputStream();
+        new XMLSerializer(contentOutStream, new OutputFormat(contentXML)).serialize(contentXML);
+        XDocArchive.setEntry(outputArchive, "content.xml", new ByteArrayInputStream(contentOutStream.toByteArray()));
+    }
+
+    private static void applyParentStyleToChildren(Document contentXML,
+                                                   Document styleXML )
+    {
+        // Get the list of styles under the office:styles element and add them to styles
+        Element officeStyles = (Element) styleXML.getDocumentElement().getElementsByTagName("office:styles").item(0);
+        NodeList styleNodeList = officeStyles.getElementsByTagName("style:style");
+        Map<String, Element> styles = new HashMap<String, Element>();
+
+        for (int i = 0; i < styleNodeList.getLength(); i++)
+        {
+            Element styleElement = (Element) styleNodeList.item(i);
+            String styleName =  styleElement.getAttribute("style:name");
+            styles.put(styleName, styleElement);
+        }
+
+        // Recurse through all the elements in the document body
+        Element body = (Element) contentXML.getDocumentElement().getElementsByTagName("office:body").item(0);
+        Map<String, Element> generatedStyles = new HashMap<String, Element>();
+        updateChildStyles(body, null, styles, generatedStyles);
+
+        // Copy the generated styles to the automatic style list in content.xml
+        Element automaticStyles = (Element) contentXML.getDocumentElement().getElementsByTagName("office:automatic-styles").item(0);
+        for (Element style : generatedStyles.values())
+        {
+            automaticStyles.appendChild(contentXML.importNode(style, true));
+        }
+    }
+
+    private static void updateChildStyles(Element element,
+                                          String parentStyleName,
+                                          Map<String, Element> styles,
+                                          Map<String, Element> generatedStyles )
+    {
+        String textNS = element.getOwnerDocument().lookupNamespaceURI("text");
+
+        // Loop through each child node setting the style appropriately
+        NodeList children = element.getChildNodes();
+        for(int i = 0; i < children.getLength(); i++)
+        {
+            if (children.item(i) instanceof Element)
+            {
+                Element childElement = (Element) children.item(i);
+                String nextParentStyleName = parentStyleName;
+                if (childElement.hasAttribute("text:style-name"))
+                {
+                    String childStyleName = childElement.getAttribute("text:style-name");
+
+                    // If this node is a XDocReport style, generate a new style with the XDocReport styling rules that inherits
+                    // from parentStyleName
+                    if (childStyleName.startsWith("XDocReport_") && parentStyleName != null)
+                    {
+                        String newStyleName = getOrCreateStyle(parentStyleName, styles.get(childStyleName), generatedStyles);
+                        childElement.setAttributeNS(textNS, "text:style-name", newStyleName);
+
+                        // Any child should inherit from this new style
+                        nextParentStyleName = newStyleName;
+                    }
+                    else
+                    {
+                        // Any child should inherit from this elements style
+                        nextParentStyleName = childStyleName;
+                    }
+                }
+
+                // Finally we should update any children of this element
+                updateChildStyles(childElement, nextParentStyleName, styles, generatedStyles);
+            }
+        }
+    }
+
+    private static String getOrCreateStyle(String parentStyleName, Element styleToMerge, Map<String, Element> newStyles)
+    {
+        String styleNsUri = styleToMerge.getOwnerDocument().lookupNamespaceURI("style");
+        String styleToMergeName = styleToMerge.getAttribute("style:name");
+        String mergedStyleName = parentStyleName + "_" + styleToMergeName;
+
+        // if we've not already generated this style then copy the XDocReport style making it inherit from parentStyleName
+        if (!newStyles.containsKey(mergedStyleName))
+        {
+            Element newStyle = (Element) styleToMerge.cloneNode(true);
+            newStyle.setAttributeNS(styleNsUri, "style:name", mergedStyleName);
+            newStyle.setAttributeNS(styleNsUri, "style:parent-style-name", parentStyleName);
+            newStyles.put(mergedStyleName, newStyle);
+        }
+
+        return mergedStyleName;
     }
 
     @Override

--- a/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/TestODTPostProcessing.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/TestODTPostProcessing.java
@@ -1,0 +1,186 @@
+package fr.opensagres.xdocreport.document.odt;
+
+import fr.opensagres.xdocreport.core.io.XDocArchive;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TestODTPostProcessing
+{
+    class ElementWrapper
+    {
+        private Element mElement;
+        ElementWrapper(Element pElement)
+        {
+            mElement = pElement;
+        }
+
+        private ElementWrapper getElement( String pTagName)
+        {
+            return new ElementWrapper((Element) mElement.getElementsByTagName(pTagName).item(0));
+        }
+
+        private ElementWrapper assertStyleName(String pName)
+        {
+            assertEquals(pName, getStyleName());
+            return this;
+        }
+
+        private ElementWrapper assertAttributeEqual(String pAttributeName, String pExpectedValue)
+        {
+            assertEquals(pExpectedValue, mElement.getAttribute(pAttributeName));
+            return this;
+        }
+
+        private String getStyleName()
+        {
+            return  mElement.getAttribute("text:style-name");
+        }
+
+        private List<ElementWrapper> getChildElements()
+        {
+            List<ElementWrapper> lChildren = new LinkedList<ElementWrapper>();
+            NodeList lChildNodes = mElement.getChildNodes();
+
+            for (int i = 0; i < lChildNodes.getLength(); i++)
+            {
+                if (lChildNodes.item(i) instanceof Element){
+                    lChildren.add(new ElementWrapper((Element) lChildNodes.item(i)));
+                }
+            }
+
+            return lChildren;
+        }
+    }
+
+    private Document parseXMLInputStream(InputStream pInputStream)
+        throws ParserConfigurationException, IOException, SAXException
+    {
+        DocumentBuilderFactory lDocumentBuilderFactory = DocumentBuilderFactory.newInstance();
+        lDocumentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder lDocumentBuilder = lDocumentBuilderFactory.newDocumentBuilder();
+
+        return lDocumentBuilder.parse(pInputStream);
+    }
+
+    private XDocArchive loadTestArchive()
+        throws IOException, ParserConfigurationException
+    {
+
+
+        XDocArchive lXDocArchive = new XDocArchive();
+        XDocArchive.setEntry(lXDocArchive, "content.xml", getClass().getResourceAsStream("postprocesstestxml/content.xml"));
+        XDocArchive.setEntry(lXDocArchive, "styles.xml", getClass().getResourceAsStream("postprocesstestxml/styles.xml"));
+
+        return lXDocArchive;
+    }
+
+    @Test
+    public void testStyleNameGeneration()
+        throws Exception
+    {
+        XDocArchive lXDocArchive = loadTestArchive();
+
+        new ODTReport().doPostprocessIfNeeded(lXDocArchive);
+
+        Document lContent = parseXMLInputStream(lXDocArchive.getEntryInputStream("content.xml"));
+
+        new ElementWrapper(lContent.getDocumentElement())
+            .getElement("office:body")
+            .getElement("office:text")
+            .getElement("text:p")
+            .getElement("text:span")
+            .assertStyleName("T2")
+            .getElement("text:span")
+            .assertStyleName("T2_XDocReport_Bold")
+            .getElement("text:span")
+            .assertStyleName("T2_XDocReport_Bold_XDocReport_Italic");
+    }
+
+    @Test
+    public void testStyleT2BoldGeneration()
+        throws Exception
+    {
+        XDocArchive lXDocArchive = loadTestArchive();
+        new ODTReport().doPostprocessIfNeeded(lXDocArchive);
+
+        Document lContent = parseXMLInputStream(lXDocArchive.getEntryInputStream("content.xml"));
+
+        List<ElementWrapper> automaticStyles = new ElementWrapper(lContent.getDocumentElement())
+            .getElement("office:automatic-styles")
+            .getChildElements();
+
+        ElementWrapper T2BoldStyle = null;
+        for (ElementWrapper styleElement : automaticStyles)
+        {
+            if("T2_XDocReport_Bold".equals(styleElement.mElement.getAttribute("style:name")))
+            {
+                T2BoldStyle = styleElement;
+            }
+        }
+
+
+        if (T2BoldStyle != null){
+            T2BoldStyle
+                .assertAttributeEqual("style:parent-style-name", "T2")
+                .assertAttributeEqual("style:name", "T2_XDocReport_Bold")
+                .getElement("style:text-properties")
+                .assertAttributeEqual("fo:font-weight", "bold");
+        }
+        else
+        {
+            fail("Missing style T2_XDocReport_Bold");
+        }
+    }
+
+    @Test
+    public void testStyleT2BoldItalicGeneration()
+        throws Exception
+    {
+        XDocArchive lXDocArchive = loadTestArchive();
+        new ODTReport().doPostprocessIfNeeded(lXDocArchive);
+
+        Document lContent = parseXMLInputStream(lXDocArchive.getEntryInputStream("content.xml"));
+
+        List<ElementWrapper> automaticStyles = new ElementWrapper(lContent.getDocumentElement())
+            .getElement("office:automatic-styles")
+            .getChildElements();
+
+        ElementWrapper T2BoldStyle = null;
+        for (ElementWrapper styleElement : automaticStyles)
+        {
+            if("T2_XDocReport_Bold_XDocReport_Italic".equals(styleElement.mElement.getAttribute("style:name")))
+            {
+                T2BoldStyle = styleElement;
+            }
+        }
+
+
+        if ( T2BoldStyle != null )
+        {
+            T2BoldStyle
+                .assertAttributeEqual("style:parent-style-name", "T2_XDocReport_Bold")
+                .assertAttributeEqual("style:name", "T2_XDocReport_Bold_XDocReport_Italic")
+                .getElement("style:text-properties")
+                .assertAttributeEqual("fo:font-style", "italic");
+        }
+        else
+        {
+            fail("Missing style T2_XDocReport_Bold_XDocReport_Italic");
+        }
+    }
+
+}

--- a/document/fr.opensagres.xdocreport.document.odt/src/test/resources/fr/opensagres/xdocreport/document/odt/postprocesstestxml/content.xml
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/resources/fr/opensagres/xdocreport/document/odt/postprocesstestxml/content.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content office:version="1.2"
+  xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0"
+  xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0"
+  xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0"
+  xmlns:db="urn:oasis:names:tc:opendocument:xmlns:database:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0"
+  xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+  xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"
+  xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0"
+  xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:math="http://www.w3.org/1998/Math/MathML"
+  xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+  xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"
+  xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0"
+  xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0"
+  xmlns:smil="urn:oasis:names:tc:opendocument:xmlns:smil-compatible:1.0"
+  xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+  xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <office:font-face-decls>
+    <style:font-face style:font-family-generic="swiss" style:font-pitch="variable"
+      style:name="Calibri" svg:font-family="Calibri" svg:panose-1="2 15 5 2 2 2 4 3 2 4"/>
+    <style:font-face style:font-family-generic="roman" style:font-pitch="variable"
+      style:name="Times New Roman" svg:font-family="Times New Roman"
+      svg:panose-1="2 2 6 3 5 4 5 2 3 4"/>
+    <style:font-face style:font-family-generic="swiss" style:font-pitch="variable"
+      style:name="Segoe UI" svg:font-family="Segoe UI" svg:panose-1="2 11 5 2 4 2 4 2 2 3"/>
+    <style:font-face style:font-family-generic="swiss" style:font-pitch="variable"
+      style:name="Arial" svg:font-family="Arial" svg:panose-1="2 11 6 4 2 2 2 2 2 4"/>
+    <style:font-face style:font-family-generic="swiss" style:font-pitch="variable"
+      style:name="Calibri Light" svg:font-family="Calibri Light" svg:panose-1="2 15 3 2 2 2 4 3 2 4"
+    />
+  </office:font-face-decls>
+  <office:automatic-styles>
+    <style:style style:family="text" style:name="P1" style:parent-style-name="DefaultParagraphFont">
+      <style:text-properties style:country-asian="GB" style:font-name="Arial" style:font-name-complex="Arial" style:language-asian="en"/>
+    </style:style>
+    <style:style style:family="text" style:name="T1" style:parent-style-name="DefaultParagraphFont">
+      <style:text-properties style:country-asian="GB" style:font-name="Arial" style:font-name-complex="Arial" style:language-asian="en"/>
+    </style:style>
+  </office:automatic-styles>
+  <office:body>
+    <office:text text:use-soft-page-breaks="true">
+      <text:p text:style-name="P1">
+        <text:span text:style-name="T2">
+          <text:span text:style-name="XDocReport_Bold">This should be bold <text:span text:style-name="XDocReport_Italic">and this, bold and itallic</text:span></text:span>
+        </text:span>
+      </text:p>
+    </office:text>
+  </office:body>
+</office:document-content>

--- a/document/fr.opensagres.xdocreport.document.odt/src/test/resources/fr/opensagres/xdocreport/document/odt/postprocesstestxml/styles.xml
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/resources/fr/opensagres/xdocreport/document/odt/postprocesstestxml/styles.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<office:document-styles xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0"
+  xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0"
+  xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0"
+  xmlns:db="urn:oasis:names:tc:opendocument:xmlns:database:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0"
+  xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+  xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"
+  xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0"
+  xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:math="http://www.w3.org/1998/Math/MathML"
+  xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+  xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0"
+  xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0"
+  xmlns:smil="urn:oasis:names:tc:opendocument:xmlns:smil-compatible:1.0"
+  xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+  xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.2">
+  <office:styles>
+    <style:style style:name="XDocReport_EmptyText" style:family="text">
+      <style:text-properties/>
+    </style:style>
+    <style:style style:name="XDocReport_Bold" style:family="text">
+      <style:text-properties fo:font-weight="bold"/>
+    </style:style>
+    <style:style style:name="XDocReport_Italic" style:family="text">
+      <style:text-properties fo:font-style="italic"/>
+    </style:style>
+    <style:style style:name="XDocReport_Underline" style:family="text">
+      <style:text-properties style:text-underline-style="solid" style:text-underline-width="auto"
+        style:text-underline-color="font-color"/>
+    </style:style>
+  </office:styles>
+</office:document-styles>

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
@@ -578,6 +578,7 @@ public abstract class AbstractXDocReport
     }
 
     protected void doPostprocessIfNeeded( XDocArchive outputArchive )
+    throws Exception
     {
         // Empty default impl to avoid breaking compat
     }


### PR DESCRIPTION
Added some prost processing that will apply styles to elements generated by the HTML -> ODF. These new styles inherit from the elements parent style but have all the style rules of the XDocReport style. 