### PR TITLE
fixed invalid getColor when it's empty

### DIFF
--- a/thirdparties-extension/org.apache.poi.xwpf.converter.core/src/main/java/org/apache/poi/xwpf/converter/core/utils/ColorHelper.java
+++ b/thirdparties-extension/org.apache.poi.xwpf.converter.core/src/main/java/org/apache/poi/xwpf/converter/core/utils/ColorHelper.java
@@ -110,7 +110,7 @@ public class ColorHelper
 
     public static Color getColor( String hexColor, Object val, boolean background )
     {
-        if ( hexColor != null )
+        if ( hexColor != null && !"".equals(hexColor) )
         {
             if ( AUTO.equals( hexColor ) )
             {


### PR DESCRIPTION
Please, if approved, could you add this fix also at version 1.0.7? Thank you!