### PR TITLE
Close input stream of an image provider after loading its info

### DIFF
--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/images/SimpleImageInfo.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/images/SimpleImageInfo.java
@@ -38,6 +38,7 @@
 package fr.opensagres.xdocreport.document.images;
 
 import fr.opensagres.xdocreport.core.document.ImageFormat;
+import fr.opensagres.xdocreport.core.io.IOUtils;
 
 import java.io.DataInput;
 import java.io.FileInputStream;
@@ -349,6 +350,10 @@ public class SimpleImageInfo implements IImageInfo {
             }
         } catch (IOException ioe) {
             return false;
+        } finally {
+            if (in != null) {
+                IOUtils.closeQuietly(in);
+            }
         }
     }
 

--- a/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/images/FileImageProviderTestCase.java
+++ b/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/images/FileImageProviderTestCase.java
@@ -24,12 +24,11 @@
  */
 package fr.opensagres.xdocreport.document.images;
 
-import java.io.File;
-
+import fr.opensagres.xdocreport.core.document.ImageFormat;
 import org.junit.Assert;
 import org.junit.Test;
 
-import fr.opensagres.xdocreport.core.document.ImageFormat;
+import java.io.*;
 
 public class FileImageProviderTestCase
 {
@@ -177,5 +176,26 @@ public class FileImageProviderTestCase
         Assert.assertEquals( 1100f, imageProvider.getWidth(null).floatValue(), 0 );
         Assert.assertNotNull( imageProvider.getHeight(null) );
         Assert.assertEquals( 1000f, imageProvider.getHeight(null).floatValue(), 0 );
+    }
+
+    @Test
+    public void checkIfInputStreamIsClosedAfterLoadingImageInfo() throws Exception {
+        File file = new File("src/test/resources/fr/opensagres/xdocreport/document/images/logo.png");
+        final InputStream fis = new FileInputStream(file);
+        FileImageProvider imageProvider = new FileImageProvider(file, true) {
+            @Override
+            protected InputStream getInputStream() throws IOException {
+                return fis;
+            }
+        };
+
+        imageProvider.getHeight(300f);
+
+        try {
+            // Check if stream is closed. If so, it should throw an Exception
+            fis.read();
+            Assert.fail();
+        } catch (IOException e) {
+        }
     }
 }

--- a/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/images/ImageInfoTestCase.java
+++ b/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/images/ImageInfoTestCase.java
@@ -24,6 +24,7 @@
  */
 package fr.opensagres.xdocreport.document.images;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class ImageInfoTestCase {
         assertThat(info.getMimeType().getType(), is("jpeg"));
         assertThat(info.getHeight(), is(1536));
         assertThat(info.getWidth(), is(2048));
+        checkIfStreamIsClosed(in);
     }
 
     @Test
@@ -51,6 +53,7 @@ public class ImageInfoTestCase {
         assertThat(info.getMimeType().getType(), is("jpeg"));
         assertThat(info.getHeight(), is(1536));
         assertThat(info.getWidth(), is(2048));
+        checkIfStreamIsClosed(in);
     }
 
     private IImageInfo loadImageInfo(InputStream is) throws IOException {
@@ -58,5 +61,13 @@ public class ImageInfoTestCase {
         imageInfo.setInput(is);
         imageInfo.check();
         return imageInfo;
+    }
+
+    private void checkIfStreamIsClosed(InputStream is) throws IOException {
+        try {
+            is.read();
+            Assert.fail();
+        } catch (IOException e) {
+        }
     }
 }


### PR DESCRIPTION
When trying to get image info of an AbstractInputStreamImageProvider, the provided stream is never closed.