### PR TITLE
AbstractXDocReport: improve preprocess

### DIFF
--- a/document/fr.opensagres.xdocreport.document.docx/pom.xml
+++ b/document/fr.opensagres.xdocreport.document.docx/pom.xml
@@ -12,5 +12,11 @@
 			<artifactId>fr.opensagres.xdocreport.document</artifactId>
 			<version>2.0.2-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<version>2.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/DocxReportTestCase.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/DocxReportTestCase.java
@@ -1,0 +1,54 @@
+package fr.opensagres.xdocreport.document.docx;
+
+import static org.easymock.EasyMock.*;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import fr.opensagres.xdocreport.document.IXDocReport;
+import fr.opensagres.xdocreport.document.docx.discovery.DocXReportFactoryDiscoveryTestCase;
+import fr.opensagres.xdocreport.document.registry.XDocReportRegistry;
+import fr.opensagres.xdocreport.template.ITemplateEngine;
+import fr.opensagres.xdocreport.template.formatter.IDocumentFormatter;
+import junit.framework.TestCase;
+
+public class DocxReportTestCase extends TestCase
+{
+    @Test
+    public void testPreprocess() throws Exception
+    {
+        InputStream is = DocXReportFactoryDiscoveryTestCase.class.getResourceAsStream( "DocxHelloWordWithFreemarker.docx" );
+        try {
+            IXDocReport report = XDocReportRegistry.getRegistry().loadReport( is, true );
+            
+            assertFalse("Report should not yet be preprocessed", report.isPreprocessed());
+            assertNull("Original document archive should be null, since cacheOriginalDocument is false", report.getOriginalDocumentArchive());
+            assertNotNull("Preprocessed document archive should be set", report.getPreprocessedDocumentArchive());
+            
+            // we need to set some template engine to be able to preprocess
+            report.setTemplateEngine(createTemplateEngine());
+            
+            report.preprocess();
+            
+            assertTrue("Report should be preprocessed now", report.isPreprocessed());
+            assertNull("Original archive should still be null", report.getOriginalDocumentArchive());
+            assertNotNull("Preprocessed document archive should still be set", report.getPreprocessedDocumentArchive());
+        }
+        finally
+        {
+            is.close();
+        }
+    }
+
+    private ITemplateEngine createTemplateEngine()
+    {
+        IDocumentFormatter documentFormatter = createNiceMock(IDocumentFormatter.class);
+        replay(documentFormatter);
+
+        ITemplateEngine templateEngine = createNiceMock(ITemplateEngine.class);
+        expect(templateEngine.getDocumentFormatter()).andStubReturn(documentFormatter);
+        replay(templateEngine);
+        return templateEngine;
+    }
+}

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
@@ -335,7 +335,7 @@ public abstract class AbstractXDocReport
         }
         if ( templateEngine == null )
         {
-            // template engine is not setted, preprorcessor cannot be done
+            // template engine is not set, so preprocessing cannot be done
             return;
         }
         Map<String, Object> sharedContext = new HashMap<String, Object>();
@@ -347,30 +347,27 @@ public abstract class AbstractXDocReport
         onBeforePreprocessing( sharedContext, preprocessedArchive );
         try
         {
-
             IDocumentFormatter formatter = internalGetTemplateEngine().getDocumentFormatter();
-            // Preprocessor
-            String entryName = null;
-            Set<Entry<String, Collection<IXDocPreprocessor>>> preprocessorEntryNames = preprocessors.entrySet();
+            
             // Loop for each preprocessor registered
-            for ( Entry<String, Collection<IXDocPreprocessor>> entry : preprocessorEntryNames )
+            for ( Entry<String, Collection<IXDocPreprocessor>> entry : preprocessors.entrySet() )
             {
-                entryName = entry.getKey();
+                String preprocessorName = entry.getKey();
                 Collection<IXDocPreprocessor> entryPreprocessors = entry.getValue();
-                if ( preprocessedArchive.hasEntry( entryName ) )
+                if ( preprocessedArchive.hasEntry( preprocessorName ) )
                 {
                     for ( IXDocPreprocessor preprocessor : entryPreprocessors )
                     {
                         // XML Document contains a XML file which must be
                         // preprocessed
-                        preprocessor.preprocess( entryName, preprocessedArchive, fieldsMetadata, formatter,
+                        preprocessor.preprocess( preprocessorName, preprocessedArchive, fieldsMetadata, formatter,
                                                  sharedContext );
                     }
                 }
                 else
                 {
                     // Test if it's wilcard?
-                    Set<String> entriesNameFromWilcard = preprocessedArchive.getEntryNames( entryName );
+                    Set<String> entriesNameFromWilcard = preprocessedArchive.getEntryNames( preprocessorName );
                     if ( entriesNameFromWilcard.size() > 0 )
                     {
                         for ( String entryNameFromWilcard : entriesNameFromWilcard )
@@ -389,7 +386,7 @@ public abstract class AbstractXDocReport
                         entryPreprocessors = entry.getValue();
                         for ( IXDocPreprocessor preprocessor : entryPreprocessors )
                         {
-                            if ( preprocessor.create( entryName, preprocessedArchive, fieldsMetadata, formatter,
+                            if ( preprocessor.create( preprocessorName, preprocessedArchive, fieldsMetadata, formatter,
                                                       sharedContext ) )
                             {
                                 break;

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/AbstractXDocReport.java
@@ -314,7 +314,7 @@ public abstract class AbstractXDocReport
     public void preprocess()
         throws XDocReportException, IOException
     {
-        setDocumentArchive( getOriginalDocumentArchive() );
+        doPreprocessorIfNeeded();
     }
 
     /**


### PR DESCRIPTION
improve AbstractXDocReport.preprocess by directly calling doPreprocessorIfNeeded. the old approach only worked if cacheOriginalDocument is true; otherwise getOriginalDocumentArchive returns null, causing an NPE.