### PR TITLE
Change to avoid skipping empty lines.

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
@@ -623,7 +623,7 @@ public class PdfMapper
 
     /**
      * Returns true if the iText font exists and false otherwise.
-     * 
+     *
      * @param font
      * @return
      */
@@ -722,7 +722,8 @@ public class PdfMapper
         }
         // end chunk
         Font chunkFont = getFont( font, fontAsian, fontComplex, currentGroup );
-        Chunk chunk = createTextChunk( sbuf.toString(), pageNumber, chunkFont, underlinePatterns, backgroundColor );
+        Chunk chunk = createTextChunk( textContent.isEmpty() ? " " : sbuf.toString(), pageNumber, chunkFont,
+                                       underlinePatterns, backgroundColor );
         parent.addElement( chunk );
     }
 

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
@@ -648,7 +648,7 @@ public class PdfMapper
 
     /**
      * Returns true if the iText font exists and false otherwise.
-     * 
+     *
      * @param font
      * @return
      */
@@ -758,7 +758,8 @@ public class PdfMapper
         }
         // end chunk
         Font chunkFont = getFont( font, fontAsian, fontComplex, currentGroup );
-        Chunk chunk = createTextChunk( sbuf.toString(), pageNumber, chunkFont, underlinePatterns, backgroundColor );
+        Chunk chunk = createTextChunk( textContent.isEmpty() ? " " : sbuf.toString(), pageNumber, chunkFont,
+                                       underlinePatterns, backgroundColor );
         parent.addElement( chunk );
     }
 


### PR DESCRIPTION
In DocX <line><empty line><line> is displayed with a blank line between
the other two lines. This makes the PDF version also display the blank
line.