### PR TITLE
Added override for visitStyleText

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/XWPFDocumentVisitor.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/XWPFDocumentVisitor.java
@@ -842,7 +842,7 @@ public abstract class XWPFDocumentVisitor<T, O extends Options, E extends IXWPFM
         }
         if(hasTexStyles && StringUtils.isNotEmpty(text.toString()))
         {
-        	visitStyleText(run, text.toString());
+        	visitStyleText(run, text.toString(), paragraphContainer, pageNumber);
         }
         c.dispose();
     }
@@ -858,7 +858,7 @@ public abstract class XWPFDocumentVisitor<T, O extends Options, E extends IXWPFM
      * @param text
      * @throws Exception
      */
-    protected void visitStyleText(XWPFRun run, String text) throws Exception
+    protected void visitStyleText(XWPFRun run, String text, T paragraphContainer, boolean pageNumber) throws Exception
     {
     	//child should implement
     }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
@@ -470,6 +470,12 @@ public class PdfMapper
     }
 
     @Override
+    protected void visitStyleText(XWPFRun run, String text, IITextContainer paragraphContainer, boolean pageNumber) throws Exception {
+        createAndAddChunks( paragraphContainer, text, currentRunUnderlinePatterns, currentRunBackgroundColor,
+                pageNumber, currentRunFontAscii, currentRunFontEastAsia, currentRunFontHAnsi );
+    }
+
+    @Override
     protected void visitRun( XWPFRun docxRun, boolean pageNumber, String url, IITextContainer pdfParagraphContainer )
         throws Exception
     {
@@ -543,7 +549,7 @@ public class PdfMapper
                                                    listItemFontSize != null ? listItemFontSize : fontSize,
                                                    listItemFontStyle != Font.NORMAL ? listItemFontStyle : fontStyle,
                                                    listItemFontColor != null ? listItemFontColor
-                                                                   : Converter.toBaseColor( fontColor ) );
+                                         : Converter.toBaseColor( fontColor ) );
             Chunk symbol = createTextChunk( listItemText, false, listItemFont, currentRunUnderlinePatterns,
                                             currentRunBackgroundColor );
             pdfParagraph.add( symbol );

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
@@ -659,6 +659,12 @@ public class PdfMapper
     }
 
     @Override
+    protected void visitStyleText(XWPFRun run, String text, IITextContainer paragraphContainer, boolean pageNumber) throws Exception {
+        createAndAddChunks( paragraphContainer, text, currentRunUnderlinePatterns, currentRunBackgroundColor,
+                pageNumber, currentRunFontAscii, currentRunFontEastAsia, currentRunFontHAnsi );
+    }
+
+    @Override
     protected void visitText( CTText docxText, boolean pageNumber, IITextContainer pdfParagraphContainer )
         throws Exception
     {

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
@@ -301,7 +301,7 @@ public class XHTMLMapper
     }
     
     @Override
-    protected void visitStyleText(XWPFRun run, String text) throws Exception 
+    protected void visitStyleText(XWPFRun run, String text, Object parent, boolean pageNumber) throws Exception
     {
     	if(run.getFontFamily() == null) {
 			run.setFontFamily(getStylesDocument().getFontFamilyAscii(run));


### PR DESCRIPTION
This solves the issue #264

I was facing the same issue, and from investigation looks like background color for text is not applied when using MS Word feature Text Highlight. But if you highlight text using Shadow feature, it works just fine. 

The problem was because visitor skips runs which contains some styles, therefore do not create pdf chunks at all. I have added override for visitStyleText which reuses the same functionality as in visitText. Not sure why we have two PdfMappers so added to both.

File to reproduce,  [xdocreport_background_text.docx](https://github.com/opensagres/xdocreport/files/2090665/xdocreport_background_text.docx)

All three text runs should appear in generated pdf, like in screenshot below
![screenshot 2018-06-11 18 34 50](https://user-images.githubusercontent.com/814799/41241687-47eb12d0-6da6-11e8-9066-568c62762681.png)
