### PR TITLE
Avoid blank pages at the end of sections.

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableColumnText.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableColumnText.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.poi.xwpf.converter.pdf.internal.elements;
+
+import com.itextpdf.text.Chunk;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.pdf.ColumnText;
+
+/**
+ * This is used for a StylableColumnText.
+ */
+public class StylableColumnText
+    extends ColumnText
+{
+
+    /** Constructs a StylableColumnText. */
+    public StylableColumnText()
+    {
+        super( null );
+    }
+
+    /** @return true if all of the elements are blank */
+    public boolean isBlank()
+    {
+        if ( compositeElements != null )
+        {
+            for ( Element element : compositeElements )
+            {
+                if ( !( element instanceof StylableParagraph ) )
+                {
+                    return false;
+                }
+                for ( Chunk chunk : element.getChunks() )
+                {
+                    if ( chunk.hasAttributes() || !chunk.getContent().trim().isEmpty() )
+                    {
+                        return false;
+                    }
+
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocument.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocument.java
@@ -28,14 +28,12 @@ import static fr.opensagres.poi.xwpf.converter.core.utils.DxaUtil.dxa2points;
 
 import java.io.OutputStream;
 import java.math.BigInteger;
-import java.util.Collection;
 
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageMar;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageNumber;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageSz;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
 
-import com.itextpdf.text.Chunk;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
@@ -70,7 +68,7 @@ public class StylableDocument
 
     private PdfPTable layoutTable;
 
-    private ColumnText text;
+    private StylableColumnText text;
 
     private int colIdx;
 
@@ -98,23 +96,8 @@ public class StylableDocument
         StylableDocumentSection.getCell( layoutTable, colIdx ).getColumn().addElement( element );
         try
         {
-            if ( ColumnText.hasMoreText( text.go( true ) ) )
+            if ( ColumnText.hasMoreText( text.go( true ) ) && !text.isBlank() )
             {
-                checkNotEmpty: if ( element instanceof StylableParagraph )
-                {
-                    Collection<Chunk> chunks = element.getChunks();
-                    if ( !chunks.isEmpty() )
-                    {
-                        for ( Chunk chunk : element.getChunks() )
-                        {
-                            if ( chunk.hasAttributes() || !chunk.getContent().trim().isEmpty() )
-                            {
-                                break checkNotEmpty;
-                            }
-                        }
-                        return;
-                    }
-                }
                 columnBreak();
             }
         }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocumentSection.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf.itext5/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocumentSection.java
@@ -118,7 +118,7 @@ public class StylableDocumentSection
     {
         // force calculate height because it may be zero
         // and nothing will be flushed
-        layoutTable.calculateHeights(  );
+        layoutTable.calculateHeights();
         return layoutTable;
     }
 
@@ -199,7 +199,7 @@ public class StylableDocumentSection
                 float minHeight = 0f;
                 if ( maxHeight < 0.0f )
                 {
-                    maxHeight = layoutTable.calculateHeights(  );
+                    maxHeight = layoutTable.calculateHeights();
                 }
                 float currHeight = 0.0f;
                 while ( Math.abs( maxHeight - minHeight ) > 0.1f )
@@ -438,9 +438,9 @@ public class StylableDocumentSection
         return table;
     }
 
-    public static ColumnText createColumnText()
+    public static StylableColumnText createColumnText()
     {
-        ColumnText text = new ColumnText( null );
+        StylableColumnText text = new StylableColumnText();
         // make iText first line alignment compatible with open office
         text.setAdjustFirstLine( false );
         return text;

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableColumnText.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableColumnText.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.poi.xwpf.converter.pdf.internal.elements;
+
+import com.lowagie.text.Chunk;
+import com.lowagie.text.pdf.ColumnText;
+
+/**
+ * This is used for a StylableColumnText.
+ */
+public class StylableColumnText
+    extends ColumnText
+{
+
+    /** Constructs a StylableColumnText. */
+    public StylableColumnText()
+    {
+        super( null );
+    }
+
+    /** @return true if all of the elements are blank */
+    public boolean isBlank()
+    {
+        if ( compositeElements != null )
+        {
+            for ( Object element : compositeElements )
+            {
+                if ( !( element instanceof StylableParagraph ) )
+                {
+                    return false;
+                }
+                for ( Object object : ( (StylableParagraph) element ).getChunks() )
+                {
+                    if ( object instanceof Chunk )
+                    {
+                        Chunk chunk = (Chunk) object;
+                        if ( chunk.hasAttributes() || !chunk.getContent().trim().isEmpty() )
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocument.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocument.java
@@ -28,14 +28,12 @@ import static fr.opensagres.poi.xwpf.converter.core.utils.DxaUtil.dxa2points;
 
 import java.io.OutputStream;
 import java.math.BigInteger;
-import java.util.Collection;
 
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageMar;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageNumber;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPageSz;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
 
-import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
@@ -70,7 +68,7 @@ public class StylableDocument
 
     private PdfPTable layoutTable;
 
-    private ColumnText text;
+    private StylableColumnText text;
 
     private int colIdx;
 
@@ -98,28 +96,8 @@ public class StylableDocument
         StylableDocumentSection.getCell( layoutTable, colIdx ).getColumn().addElement( element );
         try
         {
-            if ( ColumnText.hasMoreText( text.go( true ) ) )
+            if ( ColumnText.hasMoreText( text.go( true ) ) && !text.isBlank() )
             {
-                checkNotEmpty: if ( element instanceof StylableParagraph )
-                {
-                    Collection<Object> chunks = element.getChunks();
-                    if ( !chunks.isEmpty() )
-                    {
-                        for ( Object object : element.getChunks() )
-                        {
-                            if ( !( object instanceof Chunk ) )
-                            {
-                                break checkNotEmpty;
-                            }
-                            Chunk chunk = (Chunk) object;
-                            if ( chunk.hasAttributes() || !chunk.getContent().trim().isEmpty() )
-                            {
-                                break checkNotEmpty;
-                            }
-                        }
-                        return;
-                    }
-                }
                 columnBreak();
             }
         }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocumentSection.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/elements/StylableDocumentSection.java
@@ -438,9 +438,9 @@ public class StylableDocumentSection
         return table;
     }
 
-    public static ColumnText createColumnText()
+    public static StylableColumnText createColumnText()
     {
-        ColumnText text = new ColumnText( null );
+        StylableColumnText text = new StylableColumnText();
         // make iText first line alignment compatible with open office
         text.setAdjustFirstLine( false );
         return text;


### PR DESCRIPTION
This helps to avoid blank pages at the end if sections by ignoring pages
that only have blank space. Some of the new lines have been added by
XWPFDocumentVisitor.isAddNewLine returning true even when the page or
table is the last one in the section. While it would be possible to fix
XWPFDocumentVisitor.isAddNewLine not to add these, this commit also
solves the issue if the docx had an extra new lines at the end of the
page and the conversion to pdf had more space than the original docx.