### PR TITLE
Better list element handling during velocity document preprocessing.

### DIFF
--- a/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorFormattingVariableWithVelocity.java
+++ b/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorFormattingVariableWithVelocity.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.odt.preprocessor;
+
+import fr.opensagres.xdocreport.core.io.IOUtils;
+import fr.opensagres.xdocreport.template.formatter.FieldsMetadata;
+import fr.opensagres.xdocreport.template.formatter.IDocumentFormatter;
+import fr.opensagres.xdocreport.template.velocity.VelocityDocumentFormatter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+public class ODTPreprocessorFormattingVariableWithVelocity
+{
+    private static final String DOCUMENT_BEGINING = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\">"
+            + "<table:table table:name=\"Compras\" table:style-name=\"Compras\">"
+            + "<table:table-column table:style-name=\"Compras.A\"/>"
+            + "<table:table-header-rows>";
+    
+    private static final String DOCUMENT_ENDING = "</table:table-header-rows>"
+            + "</table:table>"
+            + "</office:document-content>";
+
+    private static final String ROW_BEGINING = "<table:table-row>"
+            + "<table:table-cell table:style-name=\"Compras.A1\" office:value-type=\"string\">"
+            + "<text:p text:style-name=\"P3\">";
+
+    private static final String ROW_ENDING = "</text:p>"
+            + "</table:table-cell>"
+            + "</table:table-row>";
+
+    @Test
+    public void dateFormattingInsideTable()
+            throws Exception
+    {
+        ODTPreprocessor preprocessor = new ODTPreprocessor();
+        InputStream stream =
+                IOUtils.toInputStream(DOCUMENT_BEGINING
+                        + ROW_BEGINING
+                        + "<text:text-input text:description=\"\">$dateFormatter.format('d-MM-yyyy',$row.creationDate)</text:text-input>"
+                        + ROW_ENDING
+                        + DOCUMENT_ENDING, "UTF-8" );
+        StringWriter writer = new StringWriter();
+
+        IDocumentFormatter formatter = new VelocityDocumentFormatter();
+        FieldsMetadata metadata = new FieldsMetadata();
+        metadata.addFieldAsList( "row.creationDate" );
+
+        preprocessor.preprocess( "content.xml", stream, writer, metadata, formatter, new HashMap<String, Object>() );
+
+        Assert.assertEquals( DOCUMENT_BEGINING
+                +"#foreach($item_row in $row)"
+                +ROW_BEGINING
+                +"$dateFormatter.format('d-MM-yyyy',$item_row.creationDate)"
+                +ROW_ENDING
+                +"#{end}"
+                + DOCUMENT_ENDING, writer.toString() );
+    }
+
+    @Test
+    public void dateFormattingWithBracketInsideTable()
+            throws Exception
+    {
+        ODTPreprocessor preprocessor = new ODTPreprocessor();
+        InputStream stream =
+                IOUtils.toInputStream(DOCUMENT_BEGINING
+                        +ROW_BEGINING
+                        +"<text:text-input text:description=\"\">$dateFormatter.format('d-MM-yyyy',${row.creationDate})</text:text-input>"
+                        +ROW_ENDING
+                        +DOCUMENT_ENDING, "UTF-8" );
+        StringWriter writer = new StringWriter();
+
+        IDocumentFormatter formatter = new VelocityDocumentFormatter();
+        FieldsMetadata metadata = new FieldsMetadata();
+        metadata.addFieldAsList( "row.creationDate" );
+
+        preprocessor.preprocess( "content.xml", stream, writer, metadata, formatter, new HashMap<String, Object>() );
+
+        Assert.assertEquals( DOCUMENT_BEGINING
+                +"#foreach($item_row in $row)"
+                +ROW_BEGINING
+                +"$dateFormatter.format('d-MM-yyyy',${item_row.creationDate})"
+                +ROW_ENDING
+                +"#{end}"
+                +DOCUMENT_ENDING, writer.toString() );
+    }
+
+}

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
@@ -56,9 +56,9 @@ public class VelocityDocumentFormatter
 
     private static final String END_FOREACH_DIRECTIVE = "#{end}";
 
-    private static final String DOLLAR_TOTKEN = "$";
+    private static final char DOLLAR_TOTKEN = '$';
 
-    private static final String OPEN_BRACKET_TOTKEN = "{";
+    private static final char OPEN_BRACKET_TOTKEN = '{';
 
     private final static int START_WITH_DOLLAR = 1;
 
@@ -92,7 +92,7 @@ public class VelocityDocumentFormatter
             case START_WITH_DOLLAR:
                 return StringUtils.replaceAll( content, DOLLAR_TOTKEN + fieldName, getItemToken() + fieldName );
             case START_WITH_DOLLAR_AND_BRACKET:
-                return StringUtils.replaceAll( content, DOLLAR_TOTKEN + OPEN_BRACKET_TOTKEN + fieldName,
+                return StringUtils.replaceAll( content, "" + DOLLAR_TOTKEN + OPEN_BRACKET_TOTKEN + fieldName,
                                                getItemTokenOpenBracket() + fieldName );
             default:
                 if ( forceAsField )
@@ -107,13 +107,13 @@ public class VelocityDocumentFormatter
     public String getStartLoopDirective( String itemNameList, String listName )
     {
         StringBuilder result = new StringBuilder( START_FOREACH_DIRECTIVE );
-        if ( !itemNameList.startsWith( DOLLAR_TOTKEN ) )
+        if ( itemNameList.charAt(0) != DOLLAR_TOTKEN )
         {
             result.append( DOLLAR_TOTKEN );
         }
         result.append( itemNameList );
         result.append( IN_DIRECTIVE );
-        if ( !listName.startsWith( DOLLAR_TOTKEN ) )
+        if ( listName.charAt(0) !=  DOLLAR_TOTKEN )
         {
             result.append( DOLLAR_TOTKEN );
         }
@@ -144,31 +144,36 @@ public class VelocityDocumentFormatter
         {
             return NO_VELOCITY_FIELD;
         }
-        int dollarIndex = content.indexOf( DOLLAR_TOTKEN );
-        if ( dollarIndex == -1 )
+
+        int currentIndex = -1;
+        int fieldNameIndex;
+        while((fieldNameIndex = content.indexOf(fieldName, currentIndex + 1)) != -1)
         {
-            // Not velocity field
-            return NO_VELOCITY_FIELD;
-        }
-        int fieldNameIndex = content.indexOf( fieldName );
-        if ( fieldNameIndex == -1 )
-        {
-            return NO_VELOCITY_FIELD;
-        }
-        if ( fieldNameIndex == dollarIndex + 1 )
-        {
-            // ex : $name
-            return START_WITH_DOLLAR;
-        }
-        if ( fieldNameIndex == dollarIndex + 2 )
-        {
-            if ( content.charAt( fieldNameIndex - 1 ) == '{' )
+            currentIndex = currentIndex + fieldNameIndex + 1;
+            if( currentIndex == 0 )
             {
-                // ex : ${name}
-                return START_WITH_DOLLAR_AND_BRACKET;
+                //no place for dollar sign
+                continue;
             }
+
+            if( content.charAt(currentIndex - 1) == OPEN_BRACKET_TOTKEN )
+            {
+                if(currentIndex == 1)
+                {
+                    //no place for dollar sign
+                    continue;
+                }
+                if( content.charAt(currentIndex - 2) == DOLLAR_TOTKEN )
+                {
+                    return START_WITH_DOLLAR_AND_BRACKET;
+                }
+            }
+            else if( content.charAt(currentIndex - 1) == DOLLAR_TOTKEN )
+            {
+                return START_WITH_DOLLAR;
+            }
+
         }
-        // Not velocity field
         return NO_VELOCITY_FIELD;
     }
 
@@ -253,7 +258,7 @@ public class VelocityDocumentFormatter
     public String getStartIfDirective( String fieldName, boolean exists )
     {
         StringBuilder directive = new StringBuilder( START_IF_DIRECTIVE );
-        if ( !fieldName.startsWith( DOLLAR_TOTKEN ) )
+        if ( fieldName.charAt(0) != DOLLAR_TOTKEN )
         {
             directive.append( DOLLAR_TOTKEN );
         }
@@ -386,7 +391,7 @@ public class VelocityDocumentFormatter
         String item = insideLoop.substring( 0, indexBeforeIn ).trim();
         // remove $
         // item='d'
-        if ( item.startsWith( DOLLAR_TOTKEN ) )
+        if ( item.charAt(0) == DOLLAR_TOTKEN )
         {
             item = item.substring( 1, item.length() );
         }
@@ -405,7 +410,7 @@ public class VelocityDocumentFormatter
         String sequence = afterIn.substring( 0, endListIndex ).trim();
         // remove $
         // item='d'
-        if ( sequence.startsWith( DOLLAR_TOTKEN ) )
+        if ( sequence.charAt(0) == DOLLAR_TOTKEN )
         {
             sequence = sequence.substring( 1, sequence.length() );
         }
@@ -443,7 +448,7 @@ public class VelocityDocumentFormatter
             fieldName = fieldName.substring( 0, fieldName.length() );
         }
         // fieldNameWithoutDollar='developers.Name'
-        String fieldNameWithoutDollar = fieldName.substring( dollarIndex + DOLLAR_TOTKEN.length(), fieldName.length() );
+        String fieldNameWithoutDollar = fieldName.substring( dollarIndex + 1, fieldName.length() );
         int lastDotIndex = fieldNameWithoutDollar.lastIndexOf( '.' );
         if ( lastDotIndex == -1 )
         {


### PR DESCRIPTION
VelocityDocumentFormatter.getModelFieldType(...) function was checking only first dollar sign occurence when looking for list field. I changed it to look for variable name instead. It is still not the best implementation - it does not look for variable name ending - it treats $catterpillar as $cat occurence. But solving that issue is harder in current implementation. Maybe i ll improve it later.

Fixes #236 