### PR TITLE
Treated ODT annotations like script container.

### DIFF
--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTConstants.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTConstants.java
@@ -66,6 +66,22 @@ public class ODTConstants
 
     public static final String OFFICE_AUTOMATIC_STYLES_ELT = "automatic-styles";
 
+    public static final String ANNOTATION_NS = "urn:oasis:names:tc:opendocument:xmlns:office:1.0";
+
+    public static final String ANNOTATION_ELT = "annotation";
+
+    public static final String ANNOTATION_END_ELT = "annotation-end";
+
+    public static final String ANNOTATION_NAME_ATTR = "name";
+
+    public static final String ANNOTATION_CREATOR_ELT = "creator";
+
+    public static final String ANNOTATION_DATE_ELT = "date";
+
+    public static final String ANNOTATION_DC_NS = "http://purl.org/dc/elements/1.1/";
+
+    public static final String PARAGRAPH_ELT = "p";
+
     public static final String SVG_NS = "urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0";
 
     public static final String WIDTH_ATTR = "width";

--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTUtils.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/ODTUtils.java
@@ -24,6 +24,9 @@
  */
 package fr.opensagres.xdocreport.document.odt;
 
+import static fr.opensagres.xdocreport.document.odt.ODTConstants.ANNOTATION_ELT;
+import static fr.opensagres.xdocreport.document.odt.ODTConstants.ANNOTATION_END_ELT;
+import static fr.opensagres.xdocreport.document.odt.ODTConstants.ANNOTATION_NS;
 import static fr.opensagres.xdocreport.document.odt.ODTConstants.DRAW_FRAME_ELT;
 import static fr.opensagres.xdocreport.document.odt.ODTConstants.DRAW_IMAGE_ELT;
 import static fr.opensagres.xdocreport.document.odt.ODTConstants.DRAW_NS;
@@ -51,7 +54,7 @@ public class ODTUtils
 
     /**
      * Returns true if the given document archive is a ODT and false otherwise.
-     * 
+     *
      * @param documentArchive
      * @return
      */
@@ -76,7 +79,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is table:table and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -89,7 +92,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is table:table-row and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -102,7 +105,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is text:text-input and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -115,7 +118,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is draw:frame and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -128,7 +131,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is draw:image and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -141,7 +144,7 @@ public class ODTUtils
 
     /**
      * Returns true if element is text:a and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -153,8 +156,34 @@ public class ODTUtils
     }
 
     /**
+     * Returns true if element is text:annotation and false otherwise.
+     *
+     * @param uri
+     * @param localName
+     * @param name
+     * @return
+     */
+    public static boolean isAnnotation( final String uri, final String localName, final String name )
+    {
+        return ANNOTATION_NS.equals( uri ) && ANNOTATION_ELT.equals( localName );
+    }
+
+    /**
+     * Returns true if element is text:annotation-end and false otherwise.
+     *
+     * @param uri
+     * @param localName
+     * @param name
+     * @return
+     */
+    public static boolean isAnnotationEnd( final String uri, final String localName, final String name )
+    {
+        return ANNOTATION_NS.equals( uri ) && ANNOTATION_END_ELT.equals( localName );
+    }
+
+    /**
      * Returns true if element is office:automatic-styles and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name

--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTAnnotationParsingHeler.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTAnnotationParsingHeler.java
@@ -1,0 +1,305 @@
+package fr.opensagres.xdocreport.document.odt.preprocessor;
+
+import static fr.opensagres.xdocreport.document.odt.ODTConstants.ANNOTATION_DC_NS;
+import static fr.opensagres.xdocreport.document.odt.ODTConstants.PARAGRAPH_ELT;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.List;
+
+import fr.opensagres.xdocreport.core.utils.StringUtils;
+
+/**
+ * ODT annotation handler. Functions:
+ * <ul>
+ *   <li>safe iterate over blok: table:table-row, text:list-item, text:section,
+ *       using @before#foreach()$after#end syntax</li>
+ *   <li>safe replace range annotations with annotation content</li>
+ *   <li>annotation content is treated as simple unformatted text</li>
+ * </ul>
+ *
+ *
+ * <p>Created on 2018-07-06</p>
+ *
+ * @author <a href="mailto:marcin.golebski@verbis.pl">Marcin Golebski</a>
+ * @version $Id$
+ */
+public class ODTAnnotationParsingHeler
+{
+    private static final String BEFORE_LABEL = "@before";
+
+    private static final String AFTER_LABEL = "@after";
+
+    private static final List<String> PARRENTS = unmodifiableList(
+        asList( "table:table-row", "text:list-item", "text:section") );
+
+    private boolean parsing = false;
+
+    private StringBuilder content;
+
+    private boolean ignore;
+
+    private String replacement;
+
+    private String after;
+
+    private String before;
+
+    private String name;
+
+    private int index;
+
+    /**
+     * The annotation tag is parsing now.
+     *
+     * @return <code>true</code> if annotation tag is parsing now,
+     *      <code>false</code> otherwise
+     */
+    public boolean isParsing()
+    {
+        return parsing;
+    }
+
+    /**
+     * Inform this helper which component is parsed now.
+     *
+     * @param uri
+     * @param localName
+     * @param name
+     */
+    public void setCurrentElement( String uri, String localName, String name )
+    {
+        if ( ANNOTATION_DC_NS.equals(uri) )
+        {
+            ignore = true;
+            return;
+        }
+        ignore = false;
+        if( PARAGRAPH_ELT.equals(localName) && content.length()>0 )
+        {
+            content.append('\n');
+        }
+    }
+
+    /**
+     * Set the helper in the state of parsing annotation tag content.
+     *
+     * @param name the name of the annotation. Not <code>null</code>
+     *      when annotation has end element somewere in document
+     * @param index index of the annotation element. It is used to close
+     *      replacement block in proper place (replacement block is not allowed
+     *      to span over the end of enclosed tag)
+     */
+    public void setParsingBegin( String name, int index )
+    {
+        this.parsing = true;
+        this.content = new StringBuilder();
+        this.ignore = false;
+        this.before = null;
+        this.after = null;
+        this.replacement = null;
+        // avoid empty string
+        if( StringUtils.isNotEmpty( name ) )
+        {
+            this.name = name;
+        }
+        else
+        {
+            this.name = null;
+        }
+        this.index = index;
+    }
+
+    public void setParsingEnd()
+    {
+        parse();
+        parsing = false;
+    }
+
+    /**
+     * Close range annotation.
+     *
+     * @param name the name of the range annotation
+     * @param force if <code>true</code> block will be closed even if name
+     *      does not match
+     * @return <code>true</code> if the name is the name of the first oppened
+     *      annotation, <code>false</code> otherwise
+     */
+    public boolean resetRangeAnnotation( String name, boolean force )
+    {
+        if( force || ( StringUtils.isNotEmpty( name ) && name.equals(this.name) ) )
+        {
+            this.name = null;
+            this.parsing = false;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Parse the annotation content. It splits into 3 section:
+     * <ul>
+     *   <li>replacement</li>
+     *   <li>before</li>
+     *   <li>after</li>
+     * </ul>
+     */
+    private void parse()
+    {
+        int indexBefore = content.indexOf(BEFORE_LABEL);
+        int indexAfter = content.indexOf(AFTER_LABEL);
+        if ( indexBefore < 0 && indexAfter < 0 )
+        {
+            if( content.length() > 0 )
+            {
+                replacement = content.toString();
+            }
+        }
+        else if( indexBefore < 0 || indexAfter < 0)
+        {
+            if( indexBefore > 0 || indexAfter > 0 )
+            {
+                replacement = content.substring(0, Math.max( indexBefore, indexAfter) );
+            }
+            if( indexBefore < 0 )
+            {
+                after = content.substring(indexAfter + AFTER_LABEL.length(), content.length());
+            }
+            else
+            {
+                before = content.substring(indexBefore + BEFORE_LABEL.length(), content.length());
+            }
+        }
+        else if( indexBefore < indexAfter )
+        {
+            if( indexBefore > 0 )
+            {
+                replacement = content.substring(0, indexBefore);
+            }
+            before = content.substring(indexBefore + BEFORE_LABEL.length(), indexAfter);
+            after = content.substring(indexAfter + AFTER_LABEL.length(), content.length());
+        }
+        else
+        {
+            if( indexAfter > 0)
+            {
+                replacement = content.substring(0, indexAfter);
+            }
+            after = content.substring(indexAfter + AFTER_LABEL.length(), indexBefore);
+            before = content.substring(indexBefore + BEFORE_LABEL.length(), content.length());
+        }
+    }
+
+    /**
+     * Append new string into annotation content.
+     *
+     * @param value the value being appended
+     */
+    public void append( String value )
+    {
+        if( ignore )
+        {
+            return;
+        }
+        content.append(value);
+    }
+
+    /**
+     * Return type of parrents which are itrable using point-annotation.
+     *
+     * @return the list of tag names
+     */
+    public List<String> getParents()
+    {
+        return PARRENTS;
+    }
+
+    /**
+     * Check if annotation has "before" part.
+     *
+     * @return <code>true</code> if annotation has "before" part, <code>false</code>
+     *      otherwise
+     */
+    public boolean hasBefore()
+    {
+        return before != null;
+    }
+
+    /**
+     * Returns "before" part of annotation content.
+     *
+     * @return "before" part
+     */
+    public String getBefore()
+    {
+        return before;
+    }
+
+    /**
+     * Check if annotation has "after" part.
+     *
+     * @return <code>true</code> if annotation has "after" part, <code>false</code>
+     *      otherwise
+     */
+    public boolean hasAfter()
+    {
+        return after != null;
+    }
+
+    /**
+     * Returns "after" part of annotation content.
+     *
+     * @return "after" part
+     */
+    public String getAfter()
+    {
+        return after;
+    }
+
+    /**
+     * Check if annotation has "replacement" part.
+     *
+     * @return <code>true</code> if annotation has "replacement" part,
+     *      <code>false</code> otherwise
+     */
+    public boolean hasReplacement()
+    {
+        return replacement != null;
+    }
+
+    /**
+     * Returns "replacement" part of annotation content.
+     *
+     * @return "replacement" part
+     */
+    public String getReplacement()
+    {
+        return replacement;
+    }
+
+    /**
+     * Check if this anotation is "point" or "range" anotation.
+     *
+     * @return <code>true</code> if this is range annotation, <code>false</code>
+     *      otherwise
+     */
+    public boolean isRangeAnnotation()
+    {
+        return name != null;
+    }
+
+    /**
+     * Check if index of current element shows we are in the same block like
+     * anotation is. It is used to check if we should force to close range
+     * annotation which is setup across many tags.
+     *
+     * @param currentElementIndex the index of current tag
+     * @return <code>true</code> if current tag is the same container like
+     *      anotation is, <code>false</code> otherwise
+     */
+    public boolean isTheSameBlock(int currentElementIndex)
+    {
+        return currentElementIndex >= index;
+    }
+
+}

--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTBufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTBufferedDocumentContentHandler.java
@@ -322,6 +322,7 @@ public class ODTBufferedDocumentContentHandler
                     }
                 }
             }
+            return;
         }
         else if ( annotationHelper.isRangeAnnotation() && !annotationHelper.isTheSameBlock(getElementIndex()) )
         {

--- a/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTAnnotationParsingHelerTest.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTAnnotationParsingHelerTest.java
@@ -1,0 +1,143 @@
+package fr.opensagres.xdocreport.document.odt.preprocessor;
+
+import junit.framework.TestCase;
+
+/**
+ * JUnit test for {@link ODTAnnotationParsingHeler}.
+ *
+ * <p>Created on 2018-07-06</p>
+ *
+ * @author <a href="mailto:marcin.golebski@verbis.pl">Marcin Golebski</a>
+ * @version $Id$
+ */
+public class ODTAnnotationParsingHelerTest extends TestCase
+{
+    private ODTAnnotationParsingHeler helper;
+
+    public ODTAnnotationParsingHelerTest()
+    {
+        helper = new ODTAnnotationParsingHeler();
+    }
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        helper.setParsingBegin(null, 0);
+    }
+
+    public void testParse1() throws Exception
+    {
+        helper.append("#set($i='abc')\n");
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.append("@after#end");
+        helper.setParsingEnd();
+
+        assertTrue(helper.hasReplacement());
+        assertEquals("#set($i='abc')\n", helper.getReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+    public void testParse2() throws Exception
+    {
+        helper.append("#set($i='abc')\n");
+        helper.append("@after#end");
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.setParsingEnd();
+
+        assertTrue(helper.hasReplacement());
+        assertEquals("#set($i='abc')\n", helper.getReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+    public void testParse3() throws Exception
+    {
+        helper.append("@after#end");
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.setParsingEnd();
+
+        assertFalse(helper.hasReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+    public void testParse4() throws Exception
+    {
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.append("@after#end");
+        helper.setParsingEnd();
+
+        assertFalse(helper.hasReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+    public void testParse5() throws Exception
+    {
+        helper.append("#set($i='abc')\n");
+        helper.append("@after#end");
+        helper.setParsingEnd();
+
+        assertTrue(helper.hasReplacement());
+        assertEquals("#set($i='abc')\n", helper.getReplacement());
+        assertFalse(helper.hasBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+    public void testParse6() throws Exception
+    {
+        helper.append("#set($i='abc')\n");
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.setParsingEnd();
+
+        assertTrue(helper.hasReplacement());
+        assertEquals("#set($i='abc')\n", helper.getReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertFalse(helper.hasAfter());
+    }
+
+    public void testParse7() throws Exception
+    {
+        helper.append("#set($i='abc')\n");
+        helper.setParsingEnd();
+
+        assertTrue(helper.hasReplacement());
+        assertEquals("#set($i='abc')\n", helper.getReplacement());
+        assertFalse(helper.hasBefore());
+        assertFalse(helper.hasAfter());
+    }
+
+    public void testParse8() throws Exception
+    {
+        helper.append("@before#foreach($j in ['a','b','c'])");
+        helper.setParsingEnd();
+
+        assertFalse(helper.hasReplacement());
+        assertTrue(helper.hasBefore());
+        assertEquals("#foreach($j in ['a','b','c'])", helper.getBefore());
+        assertFalse(helper.hasAfter());
+    }
+
+    public void testParse9() throws Exception
+    {
+        helper.append("@after#end");
+        helper.setParsingEnd();
+
+        assertFalse(helper.hasReplacement());
+        assertFalse(helper.hasBefore());
+        assertTrue(helper.hasAfter());
+        assertEquals("#end", helper.getAfter());
+    }
+
+}

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/BufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/BufferedDocumentContentHandler.java
@@ -130,22 +130,25 @@ public class BufferedDocumentContentHandler<Document extends BufferedDocument>
         return bufferedDocument.getCurrentElement();
     }
 
-    protected BufferedElement findParentElementInfo( String name )
+    protected BufferedElement findParentElementInfo( List<String> names )
     {
-        return findParentElementInfo( getCurrentElement(), name );
+        return findParentElementInfo( getCurrentElement(), names );
     }
 
-    protected BufferedElement findParentElementInfo( BufferedElement elementInfo, String name )
+    protected BufferedElement findParentElementInfo( BufferedElement elementInfo, List<String> names )
     {
         if ( elementInfo == null )
         {
             return null;
         }
-        if ( elementInfo.match( name ) )
+        for( String name : names )
         {
-            return elementInfo;
+            if ( elementInfo.match( name ) )
+            {
+                return elementInfo;
+            }
         }
-        return findParentElementInfo( elementInfo.getParent(), name );
+        return findParentElementInfo( elementInfo.getParent(), names );
     }
 
     public boolean doStartElement( String uri, String localName, String name, Attributes attributes )
@@ -345,7 +348,7 @@ public class BufferedDocumentContentHandler<Document extends BufferedDocument>
 
     /**
      * Get the SAX {@link AttributesImpl} of teh given attributes to modify attribute values.
-     * 
+     *
      * @param attributes
      * @return
      */

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/TransformedBufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/TransformedBufferedDocumentContentHandler.java
@@ -24,6 +24,8 @@
  */
 package fr.opensagres.xdocreport.document.preprocessor.sax;
 
+import static java.util.Collections.singletonList;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,7 +151,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * If a row parsing, replace fields name with well script to manage lazy loop for table row.
-     * 
+     *
      * @param content
      * @return
      */
@@ -161,7 +163,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * If a row parsing, replace fields name with well script to manage lazy loop for table row.
-     * 
+     *
      * @param content
      * @return
      */
@@ -237,7 +239,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns the before row token.
-     * 
+     *
      * @return
      */
     protected String getBeforeRowToken()
@@ -251,7 +253,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns the after row token.
-     * 
+     *
      * @return
      */
     protected String getAfterRowToken()
@@ -265,7 +267,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns the before row token.
-     * 
+     *
      * @return
      */
     protected String getBeforeTableCellToken()
@@ -279,7 +281,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns the after row token.
-     * 
+     *
      * @return
      */
     protected String getAfterTableCellToken()
@@ -312,7 +314,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns true if current element is a table and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -329,7 +331,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
 
     /**
      * Returns true if current element is a table row and false otherwise.
-     * 
+     *
      * @param uri
      * @param localName
      * @param name
@@ -362,7 +364,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
             {
                 beforeElementName = beforeElementName.substring( BEFORE_TOKEN.length(), beforeElementName.length() );
             }
-            BufferedElement elementInfo = super.findParentElementInfo( beforeElementName );
+            BufferedElement elementInfo = super.findParentElementInfo( singletonList( beforeElementName ) );
             if ( elementInfo == null )
             {
                 return false;
@@ -445,7 +447,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
             {
                 afterElementName = afterElementName.substring( AFTER_TOKEN.length(), afterElementName.length() );
             }
-            BufferedElement elementInfo = super.findParentElementInfo( afterElementName );
+            BufferedElement elementInfo = super.findParentElementInfo( singletonList( afterElementName ) );
             if ( elementInfo == null )
             {
                 return false;
@@ -540,5 +542,6 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
         return endNoParse;
     }
 
+    @Override
     protected abstract Document createDocument();
 }

--- a/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorAnnotationRangeTestCase.java
+++ b/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorAnnotationRangeTestCase.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.odt.preprocessor;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import fr.opensagres.xdocreport.core.io.IOUtils;
+import junit.framework.TestCase;
+
+/**
+ * Test JUnit for range-annotation parsing.
+ *
+ * <p>Created on 2018-07-06</p>
+ *
+ * @author <a href="mailto:marcin.golebski@verbis.pl">Marcin Golebski</a>
+ */
+public class ODTPreprocessorAnnotationRangeTestCase
+    extends TestCase
+{
+
+    private static final String START_STOP_SIMPLE_RANGE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "<office:body><office:text><text:sequence-decls>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+            + "</text:sequence-decls><text:p text:style-name=\"Standard\">Lorem ipsum "
+            + "<office:annotation office:name=\"__Annotation__0_1510414244\"><dc:creator>nieznany</dc:creator>"
+            + "<dc:date>2018-07-06T14:58:51.977923708</dc:date><text:p text:style-name=\"P1\">"
+            + "<text:span text:style-name=\"T1\">$replacement</text:span></text:p></office:annotation>dolor"
+            + "<office:annotation-end office:name=\"__Annotation__0_1510414244\"/> sit amet, consectetur adipiscing elit"
+            + "</text:p></office:text></office:body></office:document-content>";
+
+    private static final String START_STOP_BEFORE_AFTER_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "<office:body><office:text><text:sequence-decls>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+            + "</text:sequence-decls><text:p text:style-name=\"Standard\">Lorem ipsum "
+            + "<office:annotation office:name=\"__Annotation__0_1510414244\"><dc:creator>nieznany</dc:creator>"
+            + "<dc:date>2018-07-06T14:58:51</dc:date><text:p text:style-name=\"P1\">"
+            + "<text:span text:style-name=\"T1\">$replacement</text:span></text:p><text:p text:style-name=\"P1\">"
+            + "<text:span text:style-name=\"T1\">@before#foreach($replacement in $list)</text:span></text:p>"
+            + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">@after#end</text:span></text:p>"
+            + "</office:annotation>dolor<office:annotation-end office:name=\"__Annotation__0_1510414244\"/> "
+            + "sit amet, consectetur adipiscing elit"
+            + "</text:p></office:text></office:body></office:document-content>";
+
+    private static final String START_STOP_ENCLOSED_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "<office:body><office:text><text:sequence-decls>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+            + "</text:sequence-decls>"
+            + "<text:p text:style-name=\"Standard\">Lorem ipsu<office:annotation office:name=\"__Annotation__4_1000540325\">"
+            + "<dc:creator>nieznany</dc:creator><dc:date>2018-07-06T15:55:56.991618419</dc:date><text:p text:style-name=\"P2\">"
+            + "<text:span text:style-name=\"T2\">$replacement</text:span></text:p>"
+            + "</office:annotation>m <office:annotation office:name=\"__Annotation__5_1000540325\">"
+            + "<dc:creator>nieznany</dc:creator><dc:date>2018-07-06T15:56:02.462353311</dc:date>"
+            + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">$contentSkipped</text:span></text:p>"
+            + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\"/></text:p>"
+            + "</office:annotation>dolor<office:annotation-end office:name=\"__Annotation__5_1000540325\"/> sit "
+            + "<office:annotation-end office:name=\"__Annotation__4_1000540325\"/>"
+            + "amet, consectetur adipiscing elit</text:p>"
+            + "</office:text></office:body></office:document-content>";
+
+    private static final String START_STOP_CROSSTAG_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "<office:body><office:text><text:sequence-decls>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+            + "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+            + "</text:sequence-decls>"
+            + "<text:p text:style-name=\"P2\">A<office:annotation office:name=\"__Annotation__62_1000540325\"><dc:creator>"
+            + "nieznany</dc:creator><dc:date>2018-07-06T16:21:02.572291340</dc:date><text:p text:style-name=\"P3\">"
+            + "<text:span text:style-name=\"T2\">$replacement</text:span></text:p></office:annotation>b"
+            + "<text:span text:style-name=\"T1\">c</text:span></text:p><text:p text:style-name=\"P2\">abd</text:p>"
+            + "<text:p text:style-name=\"P2\"/><text:list xml:id=\"list8751044298719524852\" text:style-name=\"L1\">"
+            + "<text:list-item><text:p text:style-name=\"P1\">ab<office:annotation-end office:name=\"__Annotation__62_1000540325\"/>c"
+            + "</text:p></text:list-item><text:list-item><text:p text:style-name=\"P1\">abc</text:p></text:list-item></text:list>"
+            + "</office:text></office:body></office:document-content>";
+
+    public void testSimpleRangeAnnotation()
+            throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_SIMPLE_RANGE_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        	+ "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        	+ "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        	+ "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        	+ "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><office:body><office:text>"
+        	+ "<text:sequence-decls><text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+        	+ "</text:sequence-decls><text:p text:style-name=\"Standard\">Lorem ipsum "
+
+        	+ "$replacement"
+
+        	+ " sit amet, consectetur adipiscing elit</text:p></office:text></office:body>"
+        	+ "</office:document-content>", writer.toString() );
+    }
+
+    public void testRangeBeforeAfterAnnotation()
+            throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_BEFORE_AFTER_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        	+ "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        	+ "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        	+ "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        	+ "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><office:body><office:text>"
+        	+ "<text:sequence-decls><text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+        	+ "</text:sequence-decls>"
+
+        	+ "#foreach($replacement in $list)\n"
+
+        	+ "<text:p text:style-name=\"Standard\">Lorem ipsum "
+
+        	+ "$replacement\n"
+
+        	+ " sit amet, consectetur adipiscing elit</text:p>"
+
+        	+ "#end"
+
+        	+ "</office:text></office:body>"
+        	+ "</office:document-content>", writer.toString() );
+    }
+
+    public void testRangeEncloseAnnotation()
+            throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_ENCLOSED_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        	+ "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        	+ "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        	+ "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        	+ "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><office:body><office:text>"
+        	+ "<text:sequence-decls><text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+        	+ "</text:sequence-decls>"
+        	+ "<text:p text:style-name=\"Standard\">Lorem ipsu"
+
+        	+ "$replacement"
+
+        	+ "amet, consectetur adipiscing elit</text:p>"
+        	+ "</office:text></office:body>"
+        	+ "</office:document-content>", writer.toString() );
+    }
+
+    public void testRangeeCrosstagAnnotation()
+            throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_CROSSTAG_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        	+ "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        	+ "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        	+ "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        	+ "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><office:body><office:text>"
+        	+ "<text:sequence-decls><text:sequence-decl text:display-outline-level=\"0\" text:name=\"Illustration\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Table\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Text\"/>"
+        	+ "<text:sequence-decl text:display-outline-level=\"0\" text:name=\"Drawing\"/>"
+        	+ "</text:sequence-decls>"
+        	+ "<text:p text:style-name=\"P2\">A"
+
+        	+ "$replacement"
+
+        	+ "</text:p><text:p text:style-name=\"P2\">abd</text:p><text:p text:style-name=\"P2\"/>"
+        	+ "<text:list xml:id=\"list8751044298719524852\" text:style-name=\"L1\">"
+        	+ "<text:list-item><text:p text:style-name=\"P1\">abc</text:p></text:list-item>"
+        	+ "<text:list-item><text:p text:style-name=\"P1\">abc</text:p></text:list-item></text:list>"
+        	+ "</office:text></office:body>"
+        	+ "</office:document-content>", writer.toString() );
+    }
+
+}

--- a/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorAnnotationTestCase.java
+++ b/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTPreprocessorAnnotationTestCase.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.odt.preprocessor;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import fr.opensagres.xdocreport.core.io.IOUtils;
+import junit.framework.TestCase;
+
+/**
+ * Test JUnit for point-annotation parsing.
+ *
+ * <p>Created on 2018-07-06</p>
+ *
+ * @author <a href="mailto:marcin.golebski@verbis.pl">Marcin Golebski</a>
+ */
+public class ODTPreprocessorAnnotationTestCase
+    extends TestCase
+{
+
+    private static final String START_STOP_TABLE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+        + "<table:table table:name=\"Tableau1\" table:style-name=\"Tableau1\">"
+        + "<table:table-column table:style-name=\"Tableau1.A\"/>" + "<table:table-row>"
+        + "<table:table-cell table:style-name=\"Tableau1.A1\" office:value-type=\"string\">"
+        + "<text:p text:style-name=\"Table_20_Contents\">"
+        + "<text:text-input text:description=\"\">$i.Field</text:text-input>"
+        + "<office:annotation><dc:creator>unknown</dc:creator><dc:date>2018-07-05T15:09:04.894857589</dc:date>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">$abc@before#foreach($i in $list)</text:span></text:p>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">@after#end</text:span></text:p></office:annotation></text:p>"
+        + "</table:table-cell>" + "</table:table-row>" + "</table:table>" + "</office:document-content>";
+
+    private static final String START_STOP_LIST_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+        + "<text:list xml:id=\"list4194995166531986203\" text:style-name=\"L1\">"
+        + "<text:list-item><text:p text:style-name=\"P6\"><text:span text:style-name=\"T1\">"
+        + "<office:annotation><dc:creator>unknown</dc:creator>"
+        + "<dc:date>2018-07-05T15:09:04.894857589</dc:date>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">$abc@before#foreach($i in $list)</text:span></text:p>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">@after#end</text:span></text:p></office:annotation>"
+        + "</text:span><text:span text:style-name=\"T1\">abc</text:span></text:p></text:list-item></text:list>"
+        + "</office:document-content>";
+
+    private static final String START_STOP_SECTION_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+        + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+        + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+        + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+
+        + "<text:section text:style-name=\"Sect1\" text:name=\"Sekcja1\">"
+        + "<text:p text:style-name=\"P3\"><text:span text:style-name=\"T9\">testtest</text:span><text:span text:style-name=\"T6\">"
+        + "<office:annotation><dc:creator>unknown</dc:creator>"
+        + "<dc:date>2018-07-05T15:09:04.894857589</dc:date>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">$abc@before#foreach($i in $list)</text:span></text:p>"
+        + "<text:p text:style-name=\"P1\"><text:span text:style-name=\"T1\">@after#end</text:span></text:p></office:annotation>"
+        + "</text:span></text:p>"
+        + "</text:section>"
+        + "</office:document-content>";
+
+    public void testNestedTable()
+        throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_TABLE_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><table:table table:name=\"Tableau1\" "
+            + "table:style-name=\"Tableau1\"><table:table-column table:style-name=\"Tableau1.A\"/>"
+
+            + "#foreach($i in $list)\n"
+
+            + "<table:table-row><table:table-cell table:style-name=\"Tableau1.A1\" office:value-type=\"string\">"
+            + "<text:p text:style-name=\"Table_20_Contents\">$i.Field"
+
+            + "$abc"
+
+            + "</text:p></table:table-cell></table:table-row>"
+
+            + "#end"
+
+            + "</table:table></office:document-content>", writer.toString() );
+    }
+
+    public void testNestedList()
+        throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_LIST_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "<text:list xml:id=\"list4194995166531986203\" text:style-name=\"L1\">"
+
+            + "#foreach($i in $list)\n"
+
+            + "<text:list-item><text:p text:style-name=\"P6\"><text:span text:style-name=\"T1\">"
+
+            + "$abc"
+
+            + "</text:span><text:span text:style-name=\"T1\">abc</text:span></text:p></text:list-item>"
+
+            + "#end"
+
+            + "</text:list></office:document-content>", writer.toString() );
+    }
+
+
+    public void testNestedSection()
+            throws Exception
+    {
+        final ODTPreprocessor preprocessor = new ODTPreprocessor();
+        final InputStream stream =
+                        IOUtils.toInputStream( START_STOP_SECTION_XML, "UTF-8" );
+        final StringWriter writer = new StringWriter();
+
+        preprocessor.preprocess( "test", stream, writer, null, null, null );
+
+        assertEquals( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" "
+            + "xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\" "
+            + "xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\" "
+
+            + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\">"
+            + "#foreach($i in $list)\n"
+
+            + "<text:section text:style-name=\"Sect1\" text:name=\"Sekcja1\"><text:p "
+            + "text:style-name=\"P3\"><text:span text:style-name=\"T9\">testtest</text:span>"
+            + "<text:span text:style-name=\"T6\">"
+
+            + "$abc"
+
+            + "</text:span></text:p></text:section>"
+
+            + "#end"
+
+            + "</office:document-content>", writer.toString() );
+    }
+
+}


### PR DESCRIPTION
<office:annotation> is now treated as velocity script container with ability to
iterate over table-row, list-item and sections. Also can be treated as
the way of substituting parts of text. All this operations are desgn to
be xml safe.