### PR TITLE
Better model field type handling in Velocity

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/ModelFieldType.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/ModelFieldType.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.template.velocity;
+
+/**
+ * Type of velocity model field prefix
+ */
+enum ModelFieldType
+{
+    DOLLAR("$"),
+    DOLLAR_AND_EXCLAMATION("$!"),
+    DOLLAR_AND_BRACKET("${"),
+    DOLLAR_AND_EXCLAMATION_AND_BRACKET("$!{");
+
+    private final String prefix;
+
+    ModelFieldType(String prefix)
+    {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix()
+    {
+        return prefix;
+    }
+}

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
@@ -80,13 +80,14 @@ public class VelocityDocumentFormatter
 
     public String formatAsFieldItemList( String content, String fieldName, boolean forceAsField )
     {
-        if(forceAsField)
-        {
-            return getItemToken() + content;
-        }
+
         Set<ModelFieldType> types = getModelFieldTypes(content, fieldName);
         if(types.isEmpty())
         {
+            if(forceAsField)
+            {
+                return DOLLAR_TOKEN + getItemToken() + content;
+            }
             return content;
         }
 

--- a/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractorTestCase.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractorTestCase.java
@@ -48,28 +48,6 @@ public class VelocityFieldsExtractorTestCase
     }
 
     @Test
-    public void testExtractVariablesWithBraces()
-        throws Exception
-    {
-        Reader reader = new StringReader( "Hello ${name}!" );
-        FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
-        VelocityFieldsExtractor.getInstance().extractFields( reader, "hello", extractor );
-        Assert.assertEquals( 1, extractor.getFields().size() );
-        Assert.assertEquals( "name", extractor.getFields().get( 0 ).getName() );
-    }
-
-    @Test
-    public void testExtractVariablesNullable()
-            throws Exception
-    {
-        Reader reader = new StringReader( "Hello $!name!" );
-        FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
-        VelocityFieldsExtractor.getInstance().extractFields( reader, "hello", extractor );
-        Assert.assertEquals( 1, extractor.getFields().size() );
-        Assert.assertEquals( "name", extractor.getFields().get( 0 ).getName() );
-    }
-
-    @Test
     public void testExtractVariableInList()
         throws Exception
     {

--- a/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractorTestCase.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractorTestCase.java
@@ -24,14 +24,13 @@
  */
 package fr.opensagres.xdocreport.template.velocity;
 
-import java.io.Reader;
-import java.io.StringReader;
-
+import fr.opensagres.xdocreport.template.FieldExtractor;
+import fr.opensagres.xdocreport.template.FieldsExtractor;
 import org.junit.Assert;
 import org.junit.Test;
 
-import fr.opensagres.xdocreport.template.FieldExtractor;
-import fr.opensagres.xdocreport.template.FieldsExtractor;
+import java.io.Reader;
+import java.io.StringReader;
 
 public class VelocityFieldsExtractorTestCase
 
@@ -39,9 +38,31 @@ public class VelocityFieldsExtractorTestCase
 
     @Test
     public void testExtractVariables()
-        throws Exception
+            throws Exception
     {
         Reader reader = new StringReader( "Hello $name!" );
+        FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
+        VelocityFieldsExtractor.getInstance().extractFields( reader, "hello", extractor );
+        Assert.assertEquals( 1, extractor.getFields().size() );
+        Assert.assertEquals( "name", extractor.getFields().get( 0 ).getName() );
+    }
+
+    @Test
+    public void testExtractVariablesWithBraces()
+        throws Exception
+    {
+        Reader reader = new StringReader( "Hello ${name}!" );
+        FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
+        VelocityFieldsExtractor.getInstance().extractFields( reader, "hello", extractor );
+        Assert.assertEquals( 1, extractor.getFields().size() );
+        Assert.assertEquals( "name", extractor.getFields().get( 0 ).getName() );
+    }
+
+    @Test
+    public void testExtractVariablesNullable()
+            throws Exception
+    {
+        Reader reader = new StringReader( "Hello $!name!" );
         FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
         VelocityFieldsExtractor.getInstance().extractFields( reader, "hello", extractor );
         Assert.assertEquals( 1, extractor.getFields().size() );

--- a/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityTemplateEngineDocumentFormatterTestCase.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityTemplateEngineDocumentFormatterTestCase.java
@@ -34,15 +34,47 @@ public class VelocityTemplateEngineDocumentFormatterTestCase
         throws Exception
     {
         VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
-        String fieldName = formatter.formatAsFieldItemList( "$cds.reference", "cds.reference", false );
+        String fieldName = formatter.formatAsFieldItemList( "$cds.reference", "cds.reference" );
         assertEquals( "$item_cds.reference", fieldName );
     }
 
     public void testFormatAsFieldItemListEnclosed()
-        throws Exception
+            throws Exception
     {
         VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
-        String fieldName = formatter.formatAsFieldItemList( "${cds.reference}", "cds.reference", false );
+        String fieldName = formatter.formatAsFieldItemList( "${cds.reference}", "cds.reference"  );
         assertEquals( "${item_cds.reference}", fieldName );
+    }
+
+    public void testFormatAsFieldItemListNullable()
+            throws Exception
+    {
+        VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
+        String fieldName = formatter.formatAsFieldItemList( "$!cds.reference", "cds.reference" );
+        assertEquals( "$!item_cds.reference", fieldName );
+    }
+
+    public void testFormatAsFieldItemListThree()
+            throws Exception
+    {
+        VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
+        String fieldName = formatter.formatAsFieldItemList( "$!cds.reference$cds.reference${cds.reference}", "cds.reference" );
+        assertEquals( "$!item_cds.reference$item_cds.reference${item_cds.reference}", fieldName );
+    }
+
+    public void testFormatAsFieldItemListThreeSeparated()
+            throws Exception
+    {
+        VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
+        String fieldName = formatter.formatAsFieldItemList( "$!cds.reference $cds.reference ${cds.reference}", "cds.reference" );
+        assertEquals( "$!item_cds.reference $item_cds.reference ${item_cds.reference}", fieldName );
+    }
+
+    public void testFormatAsFieldItemListThreeSeparated_and_directive()
+            throws Exception
+    {
+        VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
+        String fieldName = formatter.formatAsFieldItemList( "Before loop #foreach($d in $cds.reference)$!cds.reference#end $cds.reference ${cds.reference}", "cds.reference" );
+        assertEquals( "Before loop #foreach($d in $item_cds.reference)$!item_cds.reference#end $item_cds.reference ${item_cds.reference}", fieldName );
     }
 }


### PR DESCRIPTION
This fixes #237 and #283. Now preprocessor replaces all found model tokens (prefixed with $ or $! or $!{ or ${). Before preprocessor was replacing only model fields of one type (first found).