### PR TITLE
Added macro @before-table and @after-table

### DIFF
--- a/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/preprocessor/sax/DocXBufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/preprocessor/sax/DocXBufferedDocumentContentHandler.java
@@ -60,6 +60,8 @@ import fr.opensagres.xdocreport.template.formatter.IDocumentFormatter;
 public class DocXBufferedDocumentContentHandler extends
 		TransformedBufferedDocumentContentHandler<DocxBufferedDocument> {
 
+	private static final String W_TBL = "w:tbl";
+	
 	private static final String W_TR = "w:tr";
 
 	private static final String W_TC = "w:tc";
@@ -79,6 +81,11 @@ public class DocXBufferedDocumentContentHandler extends
 	@Override
 	protected DocxBufferedDocument createDocument() {
 		return new DocxBufferedDocument(this);
+	}
+	
+	@Override
+	protected String getTableTableName() {
+		return W_TBL;
 	}
 
 	@Override

--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTBufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/preprocessor/ODTBufferedDocumentContentHandler.java
@@ -373,6 +373,12 @@ public class ODTBufferedDocumentContentHandler
     {
         return true;
     }
+    
+    @Override
+    protected String getTableTableName()
+    {
+        return "table:table";
+    }
 
     @Override
     protected String getTableRowName()

--- a/document/fr.opensagres.xdocreport.document.pptx/src/main/java/fr/opensagres/xdocreport/document/pptx/preprocessor/PPTXSlideContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.pptx/src/main/java/fr/opensagres/xdocreport/document/pptx/preprocessor/PPTXSlideContentHandler.java
@@ -53,6 +53,12 @@ public class PPTXSlideContentHandler
     {
         return new PPTXSlideDocument( this );
     }
+    
+    @Override
+    protected String getTableTableName()
+    {
+        return null;
+    }
 
     @Override
     protected String getTableCellName()

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/TransformedBufferedDocumentContentHandler.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/TransformedBufferedDocumentContentHandler.java
@@ -236,6 +236,34 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
     {
         return directives;
     }
+    
+    /**
+     * Returns the before table token.
+     *
+     * @return
+     */
+    protected String getBeforeTableToken()
+    {
+        if ( fieldsMetadata == null )
+        {
+            return FieldsMetadata.DEFAULT_BEFORE_TABLE_TOKEN;
+        }
+        return fieldsMetadata.getBeforeTableToken();
+    }
+
+    /**
+     * Returns the after table token.
+     *
+     * @return
+     */
+    protected String getAfterTableToken()
+    {
+        if ( fieldsMetadata == null )
+        {
+            return FieldsMetadata.DEFAULT_AFTER_TABLE_TOKEN;
+        }
+        return fieldsMetadata.getAfterTableToken();
+    }
 
     /**
      * Returns the before row token.
@@ -324,6 +352,8 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
     {
         return bufferedDocument.isTable( uri, localName, name );
     }
+    
+    protected abstract String getTableTableName();
 
     protected abstract String getTableRowName();
 
@@ -352,7 +382,11 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
         String beforeElementName = fieldName.substring( 0, index );
         if ( StringUtils.isNotEmpty( beforeElementName ) )
         {
-            if ( beforeElementName.equals( getBeforeRowToken() ) )
+        	if ( beforeElementName.equals( getBeforeTableToken() ) )
+            {
+                beforeElementName = getTableTableName();
+            }
+        	else if ( beforeElementName.equals( getBeforeRowToken() ) )
             {
                 beforeElementName = getTableRowName();
             }
@@ -387,6 +421,10 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
         {
             if ( formatter == null )
             {
+            	if ( fieldName.startsWith( getBeforeTableToken() ) )
+                {
+                    return getBeforeTableToken().length();
+                }
                 if ( fieldName.startsWith( getBeforeRowToken() ) )
                 {
                     return getBeforeRowToken().length();
@@ -397,7 +435,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
                 }
                 return -1;
             }
-            if ( !( fieldName.startsWith( BEFORE_TOKEN ) || fieldName.startsWith( getBeforeRowToken() ) || fieldName.startsWith( getBeforeTableCellToken() ) ) )
+            if ( !( fieldName.startsWith( BEFORE_TOKEN ) || fieldName.startsWith( getBeforeTableToken() ) || fieldName.startsWith( getBeforeRowToken() ) || fieldName.startsWith( getBeforeTableCellToken() ) ) )
             {
                 return -1;
             }
@@ -407,6 +445,10 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
         {
             if ( formatter == null )
             {
+            	if ( fieldName.startsWith( getAfterTableToken() ) )
+                {
+                    return getAfterTableToken().length();
+                }
                 if ( fieldName.startsWith( getAfterRowToken() ) )
                 {
                     return getAfterRowToken().length();
@@ -417,7 +459,7 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
                 }
                 return -1;
             }
-            if ( !( fieldName.startsWith( AFTER_TOKEN ) || fieldName.startsWith( getAfterRowToken() ) || fieldName.startsWith( getAfterTableCellToken() ) ) )
+            if ( !( fieldName.startsWith( AFTER_TOKEN ) || fieldName.startsWith( getAfterTableToken() ) || fieldName.startsWith( getAfterRowToken() ) || fieldName.startsWith( getAfterTableCellToken() ) ) )
             {
                 return -1;
             }
@@ -435,7 +477,11 @@ public abstract class TransformedBufferedDocumentContentHandler<Document extends
         String afterElementName = fieldName.substring( 0, index );
         if ( StringUtils.isNotEmpty( afterElementName ) )
         {
-            if ( afterElementName.equals( getAfterRowToken() ) )
+        	if ( afterElementName.equals( getAfterTableToken() ) )
+            {
+                afterElementName = getTableTableName();
+            }
+        	else if ( afterElementName.equals( getAfterRowToken() ) )
             {
                 afterElementName = getTableRowName();
             }

--- a/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/formatter/FieldsMetadata.java
+++ b/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/formatter/FieldsMetadata.java
@@ -49,6 +49,10 @@ public class FieldsMetadata
 {
 
     public static final FieldsMetadata EMPTY = new FieldsMetadata();
+    
+    public static final String DEFAULT_BEFORE_TABLE_TOKEN = "@before-table";
+
+    public static final String DEFAULT_AFTER_TABLE_TOKEN = "@after-table";
 
     public static final String DEFAULT_BEFORE_ROW_TOKEN = "@before-row";
 
@@ -68,6 +72,10 @@ public class FieldsMetadata
 
     protected final Map<String, FieldMetadata> fieldsAsTextStyling;
 
+    private String beforeTableToken;
+
+    private String afterTableToken;   
+    
     private String beforeRowToken;
 
     private String afterRowToken;
@@ -110,6 +118,8 @@ public class FieldsMetadata
         this.fieldsAsList = new HashMap<String, FieldMetadata>();
         this.fieldsAsImage = new HashMap<String, FieldMetadata>();
         this.fieldsAsTextStyling = new HashMap<String, FieldMetadata>();
+        this.beforeTableToken = DEFAULT_BEFORE_TABLE_TOKEN;
+        this.afterTableToken = DEFAULT_AFTER_TABLE_TOKEN;
         this.beforeRowToken = DEFAULT_BEFORE_ROW_TOKEN;
         this.afterRowToken = DEFAULT_AFTER_ROW_TOKEN;
         this.beforeTableCellToken = DEFAULT_BEFORE_TABLE_CELL_TOKEN;
@@ -401,6 +411,26 @@ public class FieldsMetadata
             return metadata.getFieldName();
         }
         return null;
+    }
+    
+    public String getBeforeTableToken()
+    {
+        return beforeTableToken;
+    }
+
+    public void setBeforeTableToken( String beforeTableToken )
+    {
+        this.beforeTableToken = beforeTableToken;
+    }
+
+    public String getAfterTableToken()
+    {
+        return afterTableToken;
+    }
+
+    public void setAfterTableToken( String afterTableToken )
+    {
+        this.afterTableToken = afterTableToken;
     }
 
     public String getBeforeRowToken()


### PR DESCRIPTION
When using tables, it is sometimes very convenient to insert code not only before row but also before whole table (and after table) without inserting it and new line before the table (such as when table is supposed to start at the beginning of the page). Problem with only before-row is that it will insert start of table every time. So I created this quickfix that adds two new macros `@before-table` and `@after-table` with same usage as before-row/after-row but code is inserted directly before and after table.

Example usage:
[xtest.zip](https://github.com/opensagres/xdocreport/files/2296943/xtest.zip)

Btw word will merge tables near each other which is fine. When you unzip created document, you can see that there are separate table xml elements. 
