### PR TITLE
prevent NPE by using default border size (1/4 pt) in case no Sz is given

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/utils/XWPFTableUtil.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/utils/XWPFTableUtil.java
@@ -430,6 +430,11 @@ public class XWPFTableUtil
                 // if w:sz="4" => 1/4 points
                 borderSize = size.floatValue() / 8f;
             }
+            else
+            {
+                // if no border size is set, use 1/4 pt
+                borderSize = .25f;
+            }
             Color borderColor = ColorHelper.getBorderColor( border );
             return new TableCellBorder( borderSize, borderColor, fromTableCell );
         }


### PR DESCRIPTION
As the logic in the StylableTableCell classes expects the border size to be set in case TableCellBorder::hasBorder is true since commit 3a7bb027f930a77e38d825a87085142e96e8e1c5, we should set that value in case the xml doesn't contain one.
This is e.g. the case when the table was created using apache poi, c.f. <https://github.com/apache/poi/blob/179e81c4a44ee303c0300533fe5b43ac660705a1/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFTable.java#L199-L205>