### PR TITLE
add html charset options,default value is "UTF-8"

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLOptions.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/XHTMLOptions.java
@@ -137,4 +137,14 @@ public class XHTMLOptions
         this.contentHandlerFactory = contentHandlerFactory;
         return this;
     }
+    
+    private String charset = "UTF-8";
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
 }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
@@ -132,6 +132,15 @@ public class XHTMLMapper
             startElement( HTML_ELEMENT );
             // head start
             startElement( HEAD_ELEMENT );
+            final String charset = options.getCharset();
+            if( charset != null && charset.length() >0  ) {
+                final AttributesImpl ctAttrs = new AttributesImpl();
+                //<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+                ctAttrs.addAttribute(null, "http-equiv", null, null, "Content-Type");
+                ctAttrs.addAttribute(null, "content", null, null, "text/html; charset="+charset);
+                startElement("meta",ctAttrs);
+                endElement("meta");
+            }
             if ( generateStyles )
             {
                 // styles


### PR DESCRIPTION
ie: <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

ref: https://github.com/opensagres/xdocreport/issues/307