### PR TITLE
Fix for table contents printed twice (second on new page)

### DIFF
--- a/thirdparties-extension/fr.opensagres.odfdom.converter.pdf/src/main/java/fr/opensagres/odfdom/converter/pdf/internal/stylable/StylableDocumentSection.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.pdf/src/main/java/fr/opensagres/odfdom/converter/pdf/internal/stylable/StylableDocumentSection.java
@@ -226,10 +226,9 @@ public class StylableDocumentSection
                     }
                 }
                 // populate table with last height
-                if ( currHeight != maxHeight )
-                {
-                    fillTable( maxHeight );
-                }
+                fillTable(maxHeight+0.1f); // Give our content a little more room than itext
+                // says it requires as this prevents a bug due to rounding errors when later
+                // itext claims it can't fit in content of said size
             }
             else
             {


### PR DESCRIPTION
Prevents content overflow in fr.opensagres.odfdom.converter.pdf.internal.stylable.StylableDocument#simulateText when adding content that should fit