### PR TITLE
Support vml xwpf to pdf converter

### DIFF
--- a/integrationtests/fr.opensagres.xdocreport.osgi.integrationtests/src/test/java/fr/opensagres/xdocreport/osgi/integrationtests/ConverterTest.java
+++ b/integrationtests/fr.opensagres.xdocreport.osgi.integrationtests/src/test/java/fr/opensagres/xdocreport/osgi/integrationtests/ConverterTest.java
@@ -100,7 +100,7 @@ public class ConverterTest
                         wrappedBundle( mavenBundle( "org.apache.poi", "poi", "3.8" ) ),
                         wrappedBundle( mavenBundle( "org.apache.poi", "poi-ooxml", "3.8" ) ).exports("org.apache.poi.openxml4j.opc","org.apache.poi.xwpf.usermodel"),
                         wrappedBundle( mavenBundle( "org.apache.servicemix.bundles", "org.apache.servicemix.bundles.xmlbeans", "2.4.0_5" ) ),
-                        wrappedBundle( mavenBundle( "org.apache.poi", "ooxml-schemas", "1.1" ) ),
+                        wrappedBundle( mavenBundle( "org.apache.poi", "ooxml-schemas", "1.3" ) ),
                         wrappedBundle( mavenBundle( "org.odftoolkit", "odfdom-java", "0.8.7" ) ),
                         wrappedBundle( mavenBundle( "com.lowagie", "itext", "2.1.7" ) )
 

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ImageShapeStyle.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ImageShapeStyle.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.poi.xwpf.converter.core;
+
+/**
+ * This ImageShapeStyle is read style of Picture Shape. Used for VML Picture Shape.
+ */
+public class ImageShapeStyle {
+    private static final String STYLE_DELIMITER = ";";
+    private static final String WIDTH_TOKEN = "width:";
+    private static final String HEIGHT_TOKEN = "height:";
+
+    private float height;
+    private float width;
+    private boolean canUse;
+
+    private ImageShapeStyle(float height, float width, boolean canUse) {
+        this.height = height;
+        this.width = width;
+        this.canUse = canUse;
+    }
+
+    public float getHeight() {
+        return height;
+    }
+
+    public float getWidth() {
+        return width;
+    }
+
+    public boolean isCanUse() {
+        return canUse;
+    }
+
+    public static ImageShapeStyle parse(String style) {
+        float height = 10;
+        float width = 10;
+        String[] tokens = style.split(STYLE_DELIMITER);
+        int count = 0;
+        for (String token : tokens) {
+            token = token.trim();
+            if (token.startsWith(WIDTH_TOKEN)) {
+                token = token.substring(WIDTH_TOKEN.length());
+                token = token.substring(0, token.length() - 2);
+                try {
+                    width = Float.parseFloat(token);
+                    count++;
+                } catch (NumberFormatException nfEx) {
+
+                }
+            } else if (token.startsWith(HEIGHT_TOKEN)) {
+                token = token.substring(HEIGHT_TOKEN.length());
+                token = token.substring(0, token.length() - 2);
+
+                try {
+                    height = Float.parseFloat(token);
+                    count++;
+                } catch (NumberFormatException nfEx) {
+
+                }
+            }
+        }
+        return new ImageShapeStyle(height, width, count == 2);
+    }
+}

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/XWPFDocumentVisitor.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/XWPFDocumentVisitor.java
@@ -894,7 +894,14 @@ public abstract class XWPFDocumentVisitor<T, O extends Options, E extends IXWPFM
             }
             else if ( o instanceof CTDrawing )
             {
+                //Picture - DrawingML Compatible
                 visitDrawing( (CTDrawing) o, paragraphContainer );
+            }
+            else if (o instanceof org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture)
+            {
+                //Picture - VML Compatible
+                org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture picture = (org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture) o;
+                visitVmlPicture(picture, paragraphContainer);
             }
         }
         if ( hasTexStyles && StringUtils.isNotEmpty( text.toString() ) )
@@ -1465,7 +1472,7 @@ public abstract class XWPFDocumentVisitor<T, O extends Options, E extends IXWPFM
                                 }
                             }
                         }
-                        // visit the picture.
+                        // visit the picture. DrawingML Compatible
                         visitPicture( picture, offsetX, relativeFromH, offsetY, relativeFromV, wrapText,
                                       parentContainer );
                     }
@@ -1521,4 +1528,8 @@ public abstract class XWPFDocumentVisitor<T, O extends Options, E extends IXWPFM
                                           T parentContainer )
         throws Exception;
 
+
+    protected abstract void visitVmlPicture(org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture picture,
+                                            T pdfParentContainer)
+            throws Exception;
 }

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.pdf/src/main/java/fr/opensagres/poi/xwpf/converter/pdf/internal/PdfMapper.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import com.microsoft.schemas.vml.CTImageData;
+import com.microsoft.schemas.vml.CTShape;
+import fr.opensagres.poi.xwpf.converter.core.*;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.ParagraphAlignment;
 import org.apache.poi.xwpf.usermodel.UnderlinePatterns;
@@ -47,6 +50,8 @@ import org.apache.poi.xwpf.usermodel.XWPFSDT;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
+import org.apache.xmlbeans.XmlCursor;
+import org.apache.xmlbeans.XmlObject;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTPositiveSize2D;
 import org.openxmlformats.schemas.drawingml.x2006.picture.CTPicture;
 import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.STRelFromH;
@@ -84,15 +89,6 @@ import com.lowagie.text.pdf.draw.DottedLineSeparator;
 import com.lowagie.text.pdf.draw.LineSeparator;
 import com.lowagie.text.pdf.draw.VerticalPositionMark;
 
-import fr.opensagres.poi.xwpf.converter.core.BorderSide;
-import fr.opensagres.poi.xwpf.converter.core.Color;
-import fr.opensagres.poi.xwpf.converter.core.ListItemContext;
-import fr.opensagres.poi.xwpf.converter.core.MultiValueTriplet;
-import fr.opensagres.poi.xwpf.converter.core.ParagraphLineSpacing;
-import fr.opensagres.poi.xwpf.converter.core.TableCellBorder;
-import fr.opensagres.poi.xwpf.converter.core.TableHeight;
-import fr.opensagres.poi.xwpf.converter.core.TableWidth;
-import fr.opensagres.poi.xwpf.converter.core.XWPFDocumentVisitor;
 import fr.opensagres.poi.xwpf.converter.core.styles.paragraph.ParagraphIndentationHangingValueProvider;
 import fr.opensagres.poi.xwpf.converter.core.styles.paragraph.ParagraphIndentationLeftValueProvider;
 import fr.opensagres.poi.xwpf.converter.core.utils.DxaUtil;
@@ -1329,6 +1325,56 @@ public class PdfMapper
         ExtendedPdfPTable pdfPTable = (ExtendedPdfPTable) tableContainer;
         ExtendedPdfPCell pdfPCell = (ExtendedPdfPCell) tableCellContainer;
         pdfPTable.addCell( pdfPCell );
+    }
+
+    protected void visitVmlPicture(org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture picture,
+                                   IITextContainer pdfParentContainer)
+            throws Exception
+    {
+        XmlCursor pictureCur = picture.newCursor();
+        pictureCur.selectPath("./*");
+        while (pictureCur.toNextSelection()) {
+            XmlObject obj = pictureCur.getObject();
+            if (obj instanceof CTShape) {
+                CTShape shape = (CTShape) obj;
+
+                List<CTImageData> imagedataList = shape.getImagedataList();
+                for (CTImageData imageData : imagedataList) {
+                    XWPFPictureData pictureData = getPictureDataByID(imageData.getId2());
+                    visitVmlPicture(pictureData, shape.getStyle(), pdfParentContainer);
+                }
+            }
+        }
+        pictureCur.dispose();
+    }
+
+    protected void visitVmlPicture(
+            XWPFPictureData pictureData, String style, IITextContainer pdfParentContainer)
+    {
+        if (pictureData == null) {
+            return;
+        }
+
+        try {
+            Image img = Image.getInstance(pictureData.getData());
+            ImageShapeStyle imageStyle = ImageShapeStyle.parse(style);
+            img.scaleAbsolute(imageStyle.getWidth(), imageStyle.getHeight());
+            IITextContainer parentOfParentContainer = pdfParentContainer.getITextContainer();
+            if (parentOfParentContainer != null && parentOfParentContainer instanceof PdfPCell) {
+                pdfParentContainer.addElement(img);
+            } else {
+                float chunkOffsetX = 0.0F;
+                float chunkOffsetY = 0.0F;
+                if (pdfParentContainer instanceof Paragraph) {
+                    Paragraph paragraph = (Paragraph) pdfParentContainer;
+                    paragraph.setSpacingBefore(paragraph.getSpacingBefore() + 5.0F);
+                }
+
+                pdfParentContainer.addElement(new Chunk(img, chunkOffsetX, chunkOffsetY, false));
+            }
+        } catch (Exception ex) {
+            LOGGER.severe(ex.getMessage());
+        }
     }
 
     @Override

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
@@ -606,6 +606,12 @@ public class XHTMLMapper
         }
     }
 
+    @Override
+    protected void visitVmlPicture(org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPicture picture,
+                                   Object pdfParentContainer) throws Exception {
+       //TODO: Add VML support if requited for XHTML
+    }
+
     public void setActiveMasterPage( XHTMLMasterPage masterPage )
     {
         if ( pageDiv )


### PR DESCRIPTION
Added VML support in XWPF to PDF Converter, Issue #350 

Documents having pictures/images in VML format in DOCX doesn't show in the result PDF document when DOCX converted to PDF. This issue has been fixed.

Fix has provided with this pull request.

https://github.com/opensagres/xdocreport/issues/350