### PR TITLE
Added null check on filed name to avoid throwing NullPointerException…

### DIFF
--- a/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/formatter/FieldsMetadata.java
+++ b/template/fr.opensagres.xdocreport.template/src/main/java/fr/opensagres/xdocreport/template/formatter/FieldsMetadata.java
@@ -268,6 +268,9 @@ public class FieldsMetadata
     public FieldMetadata addField( String fieldName, Boolean listType, String imageName, String syntaxKind,
                                    Boolean syntaxWithDirective )
     {
+        if(fieldName == null) {
+            throw new IllegalArgumentException("Argument 'fieldName' can not be null");
+        }
         // Test if it exists fields with the given name
         FieldMetadata exsitingField = getFieldAsImage( fieldName );
         if ( exsitingField == null )


### PR DESCRIPTION
Added null check while adding new field to FieldsMetadata, because having null value will cause NullPointerException in `TransfomrdBufferedDocumentContentHandler::getProcessRowResult`