### PR TITLE
Adds "color" to the supported styles of text styling

### DIFF
--- a/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxColorGenerator.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxColorGenerator.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2011-2020 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.docx.textstyling;
+
+import fr.opensagres.xdocreport.document.textstyling.properties.Color;
+
+/**
+ * Helper class to generate Docx Color Codes
+ */
+public class DocxColorGenerator
+{
+    /**
+     * generates a color code from a {@link fr.opensagres.xdocreport.document.textstyling.properties.Color}
+     * @param color color to convert
+     * @return docx color code
+     */
+    public static String generate( Color color )
+    {
+        String hexRed = Integer.toHexString( color.getRed() );
+        String hexGreen = Integer.toHexString( color.getGreen() );
+        String hexBlue = Integer.toHexString( color.getBlue() );
+
+        return String.format( "%2s%2s%2s", hexRed, hexGreen, hexBlue ).replaceAll( " ", "0" ).toUpperCase();
+    }
+}

--- a/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxColorGeneratorTest.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxColorGeneratorTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.docx.textstyling;
+
+import fr.opensagres.xdocreport.document.textstyling.properties.Color;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DocxColorGeneratorTest
+{
+
+    @Test
+    public void parse()
+    {
+        Assert.assertEquals( "000000", DocxColorGenerator.generate( new Color( 0, 0, 0 ) ) );
+        Assert.assertEquals( "FFFFFF", DocxColorGenerator.generate( new Color( 255, 255, 255 ) ) );
+        Assert.assertEquals( "0F8524", DocxColorGenerator.generate( new Color( 15, 133, 36 ) ) );
+    }
+}

--- a/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxDocumentHandlerTestCase.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/test/java/fr/opensagres/xdocreport/document/docx/textstyling/DocxDocumentHandlerTestCase.java
@@ -24,10 +24,6 @@
  */
 package fr.opensagres.xdocreport.document.docx.textstyling;
 
-import junit.framework.Assert;
-
-import org.junit.Test;
-
 import fr.opensagres.xdocreport.document.docx.preprocessor.DefaultStyle;
 import fr.opensagres.xdocreport.document.docx.preprocessor.sax.hyperlinks.HyperlinkInfo;
 import fr.opensagres.xdocreport.document.docx.preprocessor.sax.hyperlinks.HyperlinkRegistry;
@@ -37,13 +33,15 @@ import fr.opensagres.xdocreport.document.textstyling.IDocumentHandler;
 import fr.opensagres.xdocreport.document.textstyling.ITextStylingTransformer;
 import fr.opensagres.xdocreport.document.textstyling.html.HTMLTextStylingTransformer;
 import fr.opensagres.xdocreport.template.IContext;
+import junit.framework.Assert;
+import org.junit.Test;
 
 public class DocxDocumentHandlerTestCase
 {
 
     @Test
     public void testSpecialCharacter()
-        throws Exception
+                    throws Exception
     {
         IContext context = new MockContext();
         BufferedElement parent = null;
@@ -53,14 +51,33 @@ public class DocxDocumentHandlerTestCase
         formatter.transform( "&auml; &uuml; &eacute;", handler );
 
         Assert.assertEquals( "", handler.getTextBefore() );
-        Assert.assertEquals( "<w:r><w:t xml:space=\"preserve\" >ä </w:t></w:r><w:r><w:t xml:space=\"preserve\" >ü </w:t></w:r><w:r><w:t xml:space=\"preserve\" >é</w:t></w:r>",
-                             handler.getTextBody() );
+        Assert.assertEquals(
+                        "<w:r><w:t xml:space=\"preserve\" >ä </w:t></w:r><w:r><w:t xml:space=\"preserve\" >ü </w:t></w:r><w:r><w:t xml:space=\"preserve\" >é</w:t></w:r>",
+                        handler.getTextBody() );
+        Assert.assertEquals( "", handler.getTextEnd() );
+    }
+
+    @Test
+    public void testStyleColor()
+                    throws Exception
+    {
+        IContext context = new MockContext();
+        BufferedElement parent = null;
+
+        ITextStylingTransformer formatter = HTMLTextStylingTransformer.INSTANCE;
+        IDocumentHandler handler = new DocxDocumentHandler( parent, context, "word/document.xml" );
+        formatter.transform( "<span style=\"color: rgb(255, 0, 0);\">Test</span>", handler );
+
+        Assert.assertEquals( "", handler.getTextBefore() );
+        Assert.assertEquals(
+                        "<w:r><w:rPr><w:color w:val=\"FF0000\"/></w:rPr><w:t xml:space=\"preserve\" >Test</w:t></w:r>",
+                        handler.getTextBody() );
         Assert.assertEquals( "", handler.getTextEnd() );
     }
 
     @Test
     public void testSpecialCharacterAmp()
-        throws Exception
+                    throws Exception
     {
         IContext context = new MockContext();
         BufferedElement parent = null;

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/HTMLColorParser.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/HTMLColorParser.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.textstyling.html;
+
+import fr.opensagres.xdocreport.document.textstyling.properties.Color;
+
+/**
+ * Colors in CSS can be defined in a few different ways:
+ * - As hexadecimal values (supported)
+ * - As RGB values (supported)
+ * - By color names (unsupported)
+ * - As HSL values (CSS3) (unsupported)
+ * - As HWB values (CSS4) (unsupported)
+ * - With the currentcolor keyword (unsupported)
+ */
+public class HTMLColorParser
+{
+
+    /**
+     * @param colorString an rgb color string
+     *                    i.e. rgb(255,0,0);
+     * @return null if colorString invalid or not implemented, so that invalid arguments won't crash the program
+     */
+    public static Color parse( String colorString )
+    {
+        if ( colorString == null || colorString.isEmpty() )
+        {
+            // invalid arguments won't crash the program and are ignored...
+            return null;
+        }
+
+        // rgb( 123, 23, 1)
+        if ( colorString.startsWith( "rgb" ) )
+        {
+            return parseRgb( colorString );
+        }
+        // #FFCCAA
+        else if ( colorString.startsWith( "#" ) && colorString.length() == 7 )
+        {
+            return parseHexadecimalValues( colorString );
+        }
+        else
+        {
+            // other formats not implemented
+            return null;
+        }
+    }
+
+    private static Color parseRgb( String colorString )
+    {
+        String color = colorString.replaceAll( "[^\\d,]*", "" );
+        String[] rgbColor = color.split( "," );
+        if ( rgbColor.length == 3 )
+        {
+            try
+            {
+                return new Color( Integer.parseInt( rgbColor[0] ), Integer.parseInt( rgbColor[1] ),
+                                  Integer.parseInt( rgbColor[2] ) );
+            }
+            catch ( Exception e )
+            {
+                // invalid arguments will be ignored
+                return null;
+            }
+        }
+        else
+        {
+            // invalid arguments will be ignored
+            // opacity / alpha value not implemented yet
+            return null;
+        }
+    }
+
+    private static Color parseHexadecimalValues( String colorString )
+    {
+        String red = colorString.substring( 1, 3 );
+        String green = colorString.substring( 3, 5 );
+        String blue = colorString.substring( 5, 7 );
+        try
+        {
+            return new Color( Integer.parseInt( red, 16 ), Integer.parseInt( green, 16 ),
+                              Integer.parseInt( blue, 16 ) );
+        }
+        catch ( Exception e )
+        {
+            // invalid arguments will be ignored
+            return null;
+        }
+    }
+}

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelper.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelper.java
@@ -24,23 +24,13 @@
  */
 package fr.opensagres.xdocreport.document.textstyling.html;
 
+import fr.opensagres.xdocreport.core.utils.StringUtils;
+import fr.opensagres.xdocreport.document.textstyling.properties.*;
+import org.xml.sax.Attributes;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.xml.sax.Attributes;
-
-import fr.opensagres.xdocreport.core.utils.StringUtils;
-import fr.opensagres.xdocreport.document.textstyling.properties.ContainerProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.HeaderProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.ListItemProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.ListProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.ParagraphProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.SpanProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.TableCellProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.TableProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.TableRowProperties;
-import fr.opensagres.xdocreport.document.textstyling.properties.TextAlignment;
 
 /**
  * Styles Helper.
@@ -263,10 +253,19 @@ public class StylesHelper
             }
 
         }
+
+        // color
+        String color = stylesMap.get( "color" );
+        if ( color != null )
+        {
+            properties.setColor( HTMLColorParser.parse( color ) );
+        }
+
         // style
-        String styleName = stylesMap.get("name");
-        if (styleName != null) {
-            properties.setStyleName(styleName);
+        String styleName = stylesMap.get( "name" );
+        if ( styleName != null )
+        {
+            properties.setStyleName( styleName );
         }
     }
 

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/Color.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/Color.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2011-2020 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.textstyling.properties;
+
+/**
+ * Representation of a text color. Only supports RGB.
+ */
+public class Color
+{
+    private final int red;
+
+    private final int green;
+
+    private final int blue;
+
+    public Color( int red, int green, int blue )
+    {
+        this.red = checkColor( red );
+        this.green = checkColor( green );
+        this.blue = checkColor( blue );
+    }
+
+    public int getRed()
+    {
+        return red;
+    }
+
+    public int getGreen()
+    {
+        return green;
+    }
+
+    public int getBlue()
+    {
+        return blue;
+    }
+
+    private int checkColor( int color )
+    {
+        if ( color >= 0 && color < 256 )
+        {
+            return color;
+        }
+        throw new IllegalArgumentException( "rgb must be between 0 and 255" );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+
+        Color color = (Color) o;
+
+        if ( getRed() != color.getRed() )
+            return false;
+        if ( getGreen() != color.getGreen() )
+            return false;
+        if ( getBlue() != color.getBlue() )
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = getRed();
+        result = 31 * result + getGreen();
+        result = 31 * result + getBlue();
+        return result;
+    }
+}

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/ContainerProperties.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/properties/ContainerProperties.java
@@ -53,6 +53,8 @@ public abstract class ContainerProperties
 
     private TextAlignment textAlignment;
 
+    private Color color;
+
     private String styleName;
 
     private final ContainerType type;
@@ -157,12 +159,76 @@ public abstract class ContainerProperties
         this.textAlignment = textAlignment;
     }
 
-    public String getStyleName() {
+    public String getStyleName()
+    {
         return styleName;
     }
 
-    public void setStyleName(String styleName) {
+    public void setStyleName( String styleName )
+    {
         this.styleName = styleName;
     }
 
+    public Color getColor()
+    {
+        return color;
+    }
+
+    public void setColor( Color color )
+    {
+        this.color = color;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+
+        ContainerProperties that = (ContainerProperties) o;
+
+        if ( isPageBreakBefore() != that.isPageBreakBefore() )
+            return false;
+        if ( isPageBreakAfter() != that.isPageBreakAfter() )
+            return false;
+        if ( isBold() != that.isBold() )
+            return false;
+        if ( isItalic() != that.isItalic() )
+            return false;
+        if ( isUnderline() != that.isUnderline() )
+            return false;
+        if ( isStrike() != that.isStrike() )
+            return false;
+        if ( isSubscript() != that.isSubscript() )
+            return false;
+        if ( isSuperscript() != that.isSuperscript() )
+            return false;
+        if ( getTextAlignment() != that.getTextAlignment() )
+            return false;
+        if ( getColor() != null ? !getColor().equals( that.getColor() ) : that.getColor() != null )
+            return false;
+        if ( getStyleName() != null ? !getStyleName().equals( that.getStyleName() ) : that.getStyleName() != null )
+            return false;
+        return getType() == that.getType();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = ( isPageBreakBefore() ? 1 : 0 );
+        result = 31 * result + ( isPageBreakAfter() ? 1 : 0 );
+        result = 31 * result + ( isBold() ? 1 : 0 );
+        result = 31 * result + ( isItalic() ? 1 : 0 );
+        result = 31 * result + ( isUnderline() ? 1 : 0 );
+        result = 31 * result + ( isStrike() ? 1 : 0 );
+        result = 31 * result + ( isSubscript() ? 1 : 0 );
+        result = 31 * result + ( isSuperscript() ? 1 : 0 );
+        result = 31 * result + ( getTextAlignment() != null ? getTextAlignment().hashCode() : 0 );
+        result = 31 * result + ( getColor() != null ? getColor().hashCode() : 0 );
+        result = 31 * result + ( getStyleName() != null ? getStyleName().hashCode() : 0 );
+        result = 31 * result + ( getType() != null ? getType().hashCode() : 0 );
+        return result;
+    }
 }

--- a/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/textstyling/html/HTMLColorParserTest.java
+++ b/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/textstyling/html/HTMLColorParserTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.textstyling.html;
+
+import fr.opensagres.xdocreport.document.textstyling.properties.Color;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HTMLColorParserTest
+{
+
+	@Test
+	public void parseMinMax()
+	{
+		assertEquals( new Color( 0, 15, 255 ), HTMLColorParser.parse( "rgb(0,15,255)" ) );
+		assertEquals( new Color( 0, 15, 255 ), HTMLColorParser.parse( "#000FFF" ) );
+		assertEquals( new Color( 0, 15, 255 ), HTMLColorParser.parse( "#000fff" ) );
+	}
+
+	@Test
+	public void parseInvalidArgumentReturnsNull()
+	{
+		assertNull( HTMLColorParser.parse( "rgb(0,15,256)" ) );
+		assertNull( HTMLColorParser.parse( "#XXFFAA" ) );
+	}
+}

--- a/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelperTest.java
+++ b/document/fr.opensagres.xdocreport.document/src/test/java/fr/opensagres/xdocreport/document/textstyling/html/StylesHelperTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2011-2015 The XDocReport Team <xdocreport@googlegroups.com>
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package fr.opensagres.xdocreport.document.textstyling.html;
+
+import fr.opensagres.xdocreport.document.textstyling.properties.Color;
+import fr.opensagres.xdocreport.document.textstyling.properties.SpanProperties;
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class StylesHelperTest
+{
+
+    @Test
+    public void createSpanPropertiesColor()
+    {
+        SpanProperties expectedSpanProperties = new SpanProperties();
+        expectedSpanProperties.setColor( new Color( 230, 0, 0 ) );
+
+        Assert.assertEquals( expectedSpanProperties, StylesHelper.createSpanProperties( "color: rgb(230, 0, 0);" ) );
+    }
+
+    @Test
+    public void createSpanPropertiesColorInvalid()
+    {
+        SpanProperties expectedSpanProperties = new SpanProperties();
+
+        Assert.assertEquals( expectedSpanProperties, StylesHelper.createSpanProperties( "color: rgb(2303, 0, 0);" ) );
+        Assert.assertEquals( expectedSpanProperties, StylesHelper.createSpanProperties( "color: #123456;" ) );
+        Assert.assertEquals( expectedSpanProperties, StylesHelper.createSpanProperties( "color: invalid;" ) );
+    }
+}


### PR DESCRIPTION
The color attribute was missing in the supported styles. This pull request adds the missing support.

i. e.
`<span style="color: rgb(255, 0, 0);">Hello World</span>` or
`<span style="color: #FF0000;">Hello World</span>`
now produces 
`<w:color w:val="FF0000"/>`
in the docx xml. 