### PR TITLE
Force the charset for reading XML files and fragments to be UTF-8.

### DIFF
--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/Style.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/textstyling/Style.java
@@ -25,6 +25,7 @@
 package fr.opensagres.xdocreport.document.textstyling;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import fr.opensagres.xdocreport.core.io.IOUtils;
 import fr.opensagres.xdocreport.core.utils.StringUtils;
@@ -60,7 +61,7 @@ public class Style
         String content = "";
         try
         {
-            content = IOUtils.toString( clazz.getResourceAsStream( id + ".xml" ) );
+            content = IOUtils.toString( clazz.getResourceAsStream( id + ".xml" ), StandardCharsets.UTF_8.name() );
             content = StringUtils.replaceEach( content, searchList, replacementList );
         }
         catch ( IOException e )


### PR DESCRIPTION
In the documentation of `fr.opensagres.xdocreport.core.io.IOUtils#toString(java.io.InputStream)` it mentions

```
Get the contents of an <code>InputStream</code> as a String using the default character encoding of the platform.
```

In Windows, at least, the default character encoding will not be UTF-8. So XML files, and XML fragments using this method may not be correct. Of particular note is the XML fragment located in the `fr.opensagres.xdocreport.document.docx` project at 
`fr.opensagres.xdocreport.document.docx.textstyling.XDocReport_AbstractNum_bullet.xml` which contains characters that are not properly resolved using the default charset on Windows.

By forcing the charset to be UTF-8, the problem I encountered on Windows (and any other platforms) is resolved.

This problem manifests when rendering lists using DOCX lists and HTML lists in the same document (unordered/ordered could be involved here too)