### PR TITLE
Fix an index out of bound error

### DIFF
--- a/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/preprocessor/sax/MergefieldBufferedRegion.java
+++ b/document/fr.opensagres.xdocreport.document.docx/src/main/java/fr/opensagres/xdocreport/document/docx/preprocessor/sax/MergefieldBufferedRegion.java
@@ -239,7 +239,7 @@ public abstract class MergefieldBufferedRegion
 
     public BufferedElement getTRegion(int index)
     {
-    	return super.findChildAt( "w:t", index );       
+    	return super.findChildAt( "w:t", index );
     }
 
 }

--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/BufferedElement.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/preprocessor/sax/BufferedElement.java
@@ -338,7 +338,8 @@ public class BufferedElement implements IBufferedRegion {
 	public BufferedElement findChildAt(BufferedElement element, String name,
 			int index) {
 		List<BufferedElement> elements = findChildren(element, name);
-		if (index < elements.size()) {
+		// Check for wrong index
+		if (index >= 0 && index < elements.size()) {
 			return elements.get(index);
 		}
 		return null;


### PR DESCRIPTION
We got an error when generate pdf from docx with an image, don't know the root cause as need to investigate the docx format, however the change can help on those unnecessary error and we have tested, please approve it, thanks.

```
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248) ~[?:?]
	at java.util.Objects.checkIndex(Objects.java:372) ~[?:?]
	at java.util.ArrayList.get(ArrayList.java:458) ~[?:?]
	at fr.opensagres.xdocreport.document.preprocessor.sax.BufferedElement.findChildAt(BufferedElement.java:342) ~[xdocreport-2.0.2.jar:2.0.2]
	at fr.opensagres.xdocreport.document.preprocessor.sax.BufferedElement.findChildAt(BufferedElement.java:328) ~[xdocreport-2.0.2.jar:2.0.2]
```