### PR TITLE
getParent uses the same value all time, but must use by hierarchy.

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
@@ -68,7 +68,7 @@ public class ListContext
         ListItemContext parent = null;
         for ( int i = level; i >= 0; i-- )
         {
-            parent = listItemByLevel.get( level );
+            parent = listItemByLevel.get( /*level*/i );
             if ( parent != null )
             {
                 return parent;


### PR DESCRIPTION
Fix for mistype that created bug

you assigned 'level' to 'i' and iterate by hierarchy
for ( int i = level; i >= 0; i-- )    

but instead of calling 'i', you use 'level' all time.
And this breaks list numbers.

I checked in my fork, that code works correct now.