### PR TITLE
new STNumberFormat were added

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
@@ -68,7 +68,7 @@ public class ListContext
         ListItemContext parent = null;
         for ( int i = level; i >= 0; i-- )
         {
-            parent = listItemByLevel.get( level );
+            parent = listItemByLevel.get( /*level*/i );
             if ( parent != null )
             {
                 return parent;

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListItemContext.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListItemContext.java
@@ -120,6 +120,14 @@ public class ListItemContext
         {
             return RomanNumberFactory.getUpperCaseString( number );
         }
+        else if ( STNumberFormat.DECIMAL_ZERO.equals( numFmt ) )
+        {
+            return number < 10 ? "0" + number : String.valueOf( number );
+        }
+        else if ( STNumberFormat.NONE.equals( numFmt ) )
+        {
+            return "";
+        }
         return String.valueOf( number );
     }
 


### PR DESCRIPTION
If numbering in word doc was disabled (Numbering none) then Word doesn't show head numbers.
But converter from Word to Html adds them.

This is because code supports only a few STNumberFormat formats.
Two new formats were added DECIMAL_ZERO and NONE.

Now I see correct html (no numbers in list when they are disabled).