### PR TITLE
Fix for missed tab in HTML

### DIFF
--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/src/main/java/fr/opensagres/poi/xwpf/converter/core/ListContext.java
@@ -68,7 +68,7 @@ public class ListContext
         ListItemContext parent = null;
         for ( int i = level; i >= 0; i-- )
         {
-            parent = listItemByLevel.get( level );
+            parent = listItemByLevel.get( /*level*/i );
             if ( parent != null )
             {
                 return parent;

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.xhtml/src/main/java/fr/opensagres/poi/xwpf/converter/xhtml/internal/XHTMLMapper.java
@@ -371,6 +371,10 @@ public class XHTMLMapper
 			endElement(SPAN_ELEMENT);
 			return;
 		}
+    	else if(currentParagraph != null && tabs != null)
+    	{
+            characters(TAB_CHAR_SEQUENCE);
+        }
     }
 
     @Override


### PR DESCRIPTION
In my case I see that tab was missed in output HTML (no space between words).
This is because both currentParagraph and tabs were not empty.
I added fix for this case.