### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
+						<fork>true</fork>
+						<useIncrementalCompilation>true</useIncrementalCompilation>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -186,6 +188,10 @@
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
+					<configuration>
+						<fork>true</fork>
+						<useIncrementalCompilation>true</useIncrementalCompilation>
+					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
