### PR TITLE
POI 5.2.0

### DIFF
--- a/gae/fr.opensagres.poi.xwpf.converter.core-gae/pom.xml
+++ b/gae/fr.opensagres.poi.xwpf.converter.core-gae/pom.xml
@@ -41,19 +41,19 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.0.1</version>
+			<version>5.2.0</version>
 			<exclusions>
-				<!-- this artifact contains a subset of org.apache.poi:ooxml-schemas -->
+				<!-- Use the poi-ooxml-full instead -->
 				<exclusion>
-					<artifactId>poi-ooxml-schemas</artifactId>
 					<groupId>org.apache.poi</groupId>
+					<artifactId>poi-ooxml-lite</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
-			<artifactId>ooxml-schemas</artifactId>
-			<version>1.4</version>
+			<artifactId>poi-ooxml-full</artifactId>
+			<version>5.2.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
+++ b/thirdparties-extension/fr.opensagres.poi.xwpf.converter.core/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.1.0</version>
+			<version>5.2.0</version>
 			<exclusions>
 				<!-- Use the poi-ooxml-full instead -->
 				<exclusion>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml-full</artifactId>
-			<version>5.1.0</version>
+			<version>5.2.0</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Upgrade to POI 5.2.0 to fix some vulnerabilities.
Fix tests in fr.opensagres.poi.xwpf.converter.core-gae.