### PR TITLE
String index out of range: when #foreach has space after parenthesis

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
@@ -393,7 +393,7 @@ public class VelocityDocumentFormatter
         String item = insideLoop.substring( 0, indexBeforeIn ).trim();
         // remove $
         // item='d'
-        if ( item.charAt(0) == DOLLAR_TOKEN)
+        if ( item.length() > 0 && item.charAt(0) == DOLLAR_TOKEN)
         {
             item = item.substring( 1, item.length() );
         }

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityDocumentFormatter.java
@@ -375,7 +375,7 @@ public class VelocityDocumentFormatter
         // insideLoop='developers as d]'
         String insideLoop =
             startLoopDirective.substring( START_FOREACH_DIRECTIVE.length(), startLoopDirective.length() );
-        int indexBeforeIn = insideLoop.indexOf( " " );
+        int indexBeforeIn = insideLoop.indexOf( IN_DIRECTIVE );
         if ( indexBeforeIn == -1 )
         {
             return 0;
@@ -383,17 +383,12 @@ public class VelocityDocumentFormatter
 
         // afterItem=' in $developers]'
         String afterItem = insideLoop.substring( indexBeforeIn, insideLoop.length() );
-        int indexAfterIn = afterItem.indexOf( IN_DIRECTIVE );
-        if ( indexAfterIn == -1 )
-        {
-            return 0;
-        }
 
         // item='$d'
         String item = insideLoop.substring( 0, indexBeforeIn ).trim();
         // remove $
         // item='d'
-        if ( item.length() > 0 && item.charAt(0) == DOLLAR_TOKEN)
+        if ( item.charAt(0) == DOLLAR_TOKEN)
         {
             item = item.substring( 1, item.length() );
         }

--- a/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityTemplateEngineDocumentFormatterExtractDirectivesTestCase.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/test/java/fr/opensagres/xdocreport/template/velocity/VelocityTemplateEngineDocumentFormatterExtractDirectivesTestCase.java
@@ -105,6 +105,28 @@ public class VelocityTemplateEngineDocumentFormatterExtractDirectivesTestCase
         assertEquals( 0, directives.size() );
     }
 
+    public void test5()
+        throws Exception
+    {
+        VelocityDocumentFormatter formatter = new VelocityDocumentFormatter();
+        String content = "xxxx#foreach( $d in $developers )";
+
+        DirectivesStack directives = new DirectivesStack();
+        int nbDirective = formatter.extractListDirectiveInfo( content, directives );
+
+        assertEquals( 1, nbDirective );
+        assertEquals( 1, directives.size() );
+        LoopDirective directive = (LoopDirective) directives.get( 0 );
+        assertEquals( "developers", directive.getSequence() );
+        assertEquals( "d", directive.getItem() );
+
+        content = "#{end}";
+        nbDirective = formatter.extractListDirectiveInfo( content, directives );
+
+        assertEquals( -1, nbDirective );
+        assertEquals( 0, directives.size() );
+    }
+
     public void testIf1()
         throws Exception
     {


### PR DESCRIPTION
Fix #512:

Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0    
at java.base/java.lang.StringLatin1.charAt(StringLatin1.java:47)    
at java.base/java.lang.String.charAt(String.java:693)    
at xxxxx/fr.opensagres.xdocreport.template.velocity.VelocityDocumentFormatter.parseStartLoop(VelocityDocumentFormatter.java:396)

Thrown when #foreach expressions have a space after opening parenthesis like:

#foreach( $d in $developers )