### PR TITLE
Update to velocity 2.3 resolves: #238

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/pom.xml
+++ b/template/fr.opensagres.xdocreport.template.velocity/pom.xml
@@ -24,8 +24,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.velocity</groupId>
-			<artifactId>velocity</artifactId>
-			<version>1.7</version>
+			<artifactId>velocity-engine-core</artifactId>
+			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>oro</groupId>

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractor.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/VelocityFieldsExtractor.java
@@ -26,6 +26,7 @@ package fr.opensagres.xdocreport.template.velocity;
 
 import java.io.Reader;
 
+import org.apache.velocity.Template;
 import org.apache.velocity.runtime.RuntimeSingleton;
 import org.apache.velocity.runtime.parser.ParseException;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
@@ -49,7 +50,9 @@ public class VelocityFieldsExtractor
     {
         try
         {
-            SimpleNode document = RuntimeSingleton.parse( reader, entryName );
+            Template template = new Template();
+            template.setName( entryName );
+            SimpleNode document = RuntimeSingleton.parse( reader, template );
             ExtractVariablesVelocityVisitor visitor = new ExtractVariablesVelocityVisitor( extractor );
             visitor.setContext( null );
             document.jjtAccept( visitor, null );

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/cache/XDocReportEntryResourceLoader.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/cache/XDocReportEntryResourceLoader.java
@@ -25,8 +25,10 @@
 package fr.opensagres.xdocreport.template.velocity.cache;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 
-import org.apache.commons.collections.ExtendedProperties;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.runtime.RuntimeServices;
 import org.apache.velocity.runtime.resource.Resource;
@@ -38,6 +40,7 @@ import fr.opensagres.xdocreport.template.ITemplateEngine;
 import fr.opensagres.xdocreport.template.cache.ITemplateCacheInfoProvider;
 import fr.opensagres.xdocreport.template.utils.TemplateUtils;
 import fr.opensagres.xdocreport.template.velocity.VelocityConstants;
+import org.apache.velocity.util.ExtProperties;
 
 /**
  * Velocity resource loader {@link ResourceLoader} implementation used to cache entry name of {@link XDocArchive} which
@@ -51,21 +54,20 @@ public class XDocReportEntryResourceLoader
     private ITemplateEngine templateEngine = null;
 
     @Override
-    public void commonInit( RuntimeServices rs, ExtendedProperties configuration )
+    public void commonInit(RuntimeServices rs, ExtProperties configuration )
     {
         super.commonInit( rs, configuration );
         this.templateEngine = (ITemplateEngine) rs.getProperty( VELOCITY_TEMPLATE_ENGINE_KEY );
     }
 
     @Override
-    public void init( ExtendedProperties configuration )
+    public void init( ExtProperties configuration )
     {
         // Do nothing
     }
 
     @Override
-    public InputStream getResourceStream( String source )
-        throws ResourceNotFoundException
+    public Reader getResourceReader(String source, String encoding) throws ResourceNotFoundException
     {
         IEntryInfo cacheInfo =
             TemplateUtils.getTemplateCacheInfo( templateEngine.getTemplateCacheInfoProvider(), source );
@@ -74,7 +76,7 @@ public class XDocReportEntryResourceLoader
             InputStream inputStream = cacheInfo.getInputStream();
             if ( inputStream != null )
             {
-                return inputStream;
+                return new InputStreamReader(inputStream);
             }
         }
         throw new ResourceNotFoundException( "Cannot find input stream for the entry with source=" + source );

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
@@ -81,21 +81,6 @@ public class VelocityTemplateEngineDiscovery
             velocityEngineProperties.setProperty( "report.resource.loader.cache", "true" );
             velocityEngineProperties.setProperty( "report.resource.loader.modificationCheckInterval", "1" );
 
-            // Disable log for Velocity to avoid to generate velocity.log (by
-            // default)
-            try
-            {
-                if ( Class.forName( "org.apache.velocity.runtime.log.NullLogChute" ) != null )
-                {
-                    // Don't crash Velocity if NullLogChute doesn't exist
-                    velocityEngineProperties.setProperty( RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                                                          "org.apache.velocity.runtime.log.NullLogChute" );
-                }
-            }
-            catch ( Throwable e )
-            {
-                // Do nothing
-            }
         }
         return velocityEngineProperties;
     }

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/XDocReportEscapeReference.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/XDocReportEscapeReference.java
@@ -27,6 +27,7 @@ package fr.opensagres.xdocreport.template.velocity.internal;
 import java.util.Collection;
 
 import org.apache.velocity.app.event.implement.EscapeXmlReference;
+import org.apache.velocity.context.Context;
 import org.apache.velocity.runtime.RuntimeServices;
 
 import fr.opensagres.xdocreport.core.utils.StringUtils;
@@ -80,14 +81,14 @@ public class XDocReportEscapeReference
     }
 
     @Override
-    public Object referenceInsert( String reference, Object value )
+    public Object referenceInsert(Context context, String reference, Object value)
     {
         if ( reference != null && ( reference.startsWith( NO_ESCAPE ) || reference.startsWith( NO_ESCAPE_FCT ) ) )
         {
             // Emulate [#noescape] directive of Freemarker.
             return value;
         }
-        return super.referenceInsert( reference, value );
+        return super.referenceInsert(context, reference, value );
     }
 
 }


### PR DESCRIPTION
+ Remove the null log chute code because that seems no longer needed since velocity 2.3 uses slf4j
(and that no longer compiles)