### PR TITLE
Allow override default velocity properties in xdocreport-velocity.pro…

### DIFF
--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
@@ -56,7 +56,6 @@ public class VelocityTemplateEngineDiscovery
      */
     private synchronized Properties getVelocityEngineProperties( Properties velocityDefaultProperties, Properties xDocReportDefaultProperties )
     {
-
         Properties velocityEngineProperties = new Properties();
 
         if ( velocityDefaultProperties != null )
@@ -128,7 +127,7 @@ public class VelocityTemplateEngineDiscovery
             }
             catch ( IOException e )
             {
-                return null;
+
             }
         }
         return null;
@@ -154,7 +153,7 @@ public class VelocityTemplateEngineDiscovery
             }
             catch ( IOException e )
             {
-                return null;
+
             }
         }
         return null;

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
@@ -28,9 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.velocity.runtime.RuntimeConstants;
-
-import fr.opensagres.xdocreport.core.utils.Assert;
 import fr.opensagres.xdocreport.template.ITemplateEngine;
 import fr.opensagres.xdocreport.template.TemplateEngineKind;
 import fr.opensagres.xdocreport.template.discovery.ITemplateEngineDiscovery;
@@ -48,7 +45,8 @@ public class VelocityTemplateEngineDiscovery
     public ITemplateEngine createTemplateEngine()
     {
         Properties velocityDefaultProperties = getVelocityDefaultProperties();
-        return new VelocityTemplateEngine( getVelocityEngineProperties( velocityDefaultProperties ) );
+        Properties xDocReportDefaultProperties = getXDocReportDefaultProperties();
+        return new VelocityTemplateEngine( getVelocityEngineProperties( velocityDefaultProperties, xDocReportDefaultProperties ) );
     }
 
     /**
@@ -56,14 +54,14 @@ public class VelocityTemplateEngineDiscovery
      * 
      * @return
      */
-    private synchronized Properties getVelocityEngineProperties( Properties velocityDefaultProperties )
+    private synchronized Properties getVelocityEngineProperties( Properties velocityDefaultProperties, Properties xDocReportDefaultProperties )
     {
 
         Properties velocityEngineProperties = new Properties();
 
         if ( velocityDefaultProperties != null )
         {
-            // Use custom velocity.properties or default xdocreport-velocity.properties.
+            // Use custom velocity.properties.
             velocityEngineProperties.putAll( velocityDefaultProperties );
         }
 
@@ -101,6 +99,12 @@ public class VelocityTemplateEngineDiscovery
         // When using an invalid reference handler, also include tested references
         velocityEngineProperties.setProperty( "event_handler.invalid_references.tested", "true" );
 
+        if ( xDocReportDefaultProperties != null )
+        {
+            // Use custom xdocreport-velocity.properties.
+            velocityEngineProperties.putAll( xDocReportDefaultProperties );
+        }
+
         return velocityEngineProperties;
     }
 
@@ -111,15 +115,35 @@ public class VelocityTemplateEngineDiscovery
      */
     private synchronized Properties getVelocityDefaultProperties()
     {
-
         ClassLoader classLoader = this.getClass().getClassLoader();
         // try to load custom velocity.properties.
         InputStream is = classLoader.getResourceAsStream( "velocity.properties" );
-        if ( is == null )
+        if ( is != null )
         {
-            // custom velocity properties cannot be loaded, load xdocreport-velocity.properties
-            is = classLoader.getResourceAsStream( "xdocreport-velocity.properties" );
+            try
+            {
+                Properties p = new Properties();
+                p.load( is );
+                return p;
+            }
+            catch ( IOException e )
+            {
+                return null;
+            }
         }
+        return null;
+    }
+
+    /**
+     * Reads 'velocity.properties' from classpath
+     * 
+     * @return <code>Properties</code> loaded or <code>null</code> if is not found
+     */
+    private synchronized Properties getXDocReportDefaultProperties()
+    {
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        // try to load xdocreport-velocity.properties
+        InputStream is = classLoader.getResourceAsStream( "xdocreport-velocity.properties" );
         if ( is != null )
         {
             try


### PR DESCRIPTION
…perties

Allow override default velocity properties in xdocreport-velocity.properties

Currently, as velocity.properties always exists in resources of the velocity.jar, xdocreport-velocity.properties are never loaded, so we can't define any velocity.properties inside.

This patch allows backward compatibility properties override too.

#238