### PR TITLE
[CVE-2021-44832] Update docx4j

### DIFF
--- a/converter/fr.opensagres.xdocreport.converter.docx.docx4j/pom.xml
+++ b/converter/fr.opensagres.xdocreport.converter.docx.docx4j/pom.xml
@@ -14,9 +14,14 @@
 			<version>2.0.4-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-        	<groupId>org.docx4j</groupId>
-        	<artifactId>docx4j</artifactId>
-        	<version>2.8.1</version>
-    	</dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-core</artifactId>
+			<version>8.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.docx4j</groupId>
+			<artifactId>docx4j-export-fo</artifactId>
+			<version>8.3.2</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
should solve part of https://github.com/opensagres/xdocreport/issues/521
(unit tests are OK, not sure if I need to test further)