### PR TITLE
 avoid usage of deprecated velocity configuration properties

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.10</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/document/fr.opensagres.xdocreport.document.tools/pom.xml
+++ b/document/fr.opensagres.xdocreport.document.tools/pom.xml
@@ -143,7 +143,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/core/document/registry/XDocReportRegistryTestCase.java
+++ b/integrationtests/fr.opensagres.xdocreport.core.test/src/test/java/fr/opensagres/xdocreport/core/document/registry/XDocReportRegistryTestCase.java
@@ -290,7 +290,7 @@ public class XDocReportRegistryTestCase
 
             // Sleep with 1sec to wait that Velocity cache refresh.
             // TODO : I don't know how manage that better
-            // "report.resource.loader.modificationCheckInterval" (please see
+            // "report.resource.loader.modification_check_interval" (please see
             // VelocityTemplayteEngine) can accept
             // ONLY second interval to refresh cache???
             // Thread.sleep(1000);

--- a/integrationtests/fr.opensagres.xdocreport.osgi.integrationtests/pom.xml
+++ b/integrationtests/fr.opensagres.xdocreport.osgi.integrationtests/pom.xml
@@ -122,7 +122,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -248,7 +248,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 		</dependency>
 		<!-- for CXF D-OSGi -->
 		<dependency>

--- a/remoting/fr.opensagres.xdocreport.remoting.converter.server/pom.xml
+++ b/remoting/fr.opensagres.xdocreport.remoting.converter.server/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/remoting/fr.opensagres.xdocreport.remoting.reporting.server/pom.xml
+++ b/remoting/fr.opensagres.xdocreport.remoting.reporting.server/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/discovery/VelocityTemplateEngineDiscovery.java
@@ -65,18 +65,18 @@ public class VelocityTemplateEngineDiscovery
         }
 
         // check if XDocReportEntryResourceLoader is defined?
-        boolean hasReportLoaderDefined = velocityEngineProperties.containsKey( "report.resource.loader.class" );
+        boolean hasReportLoaderDefined = velocityEngineProperties.containsKey( "resource.loader.report.class" );
         if ( !hasReportLoaderDefined )
         {
-            // report.resource.loader.class is not defined, defines it.
+            // resource.loader.report.class is not defined, defines it.
 
             // Initialize properties to use XDocReportEntryResourceLoader to
             // load template from entry name of XDocArchive.
-            velocityEngineProperties.setProperty( "resource.loader", "file, class, jar ,report" );
-            velocityEngineProperties.setProperty( "report.resource.loader.class",
+            velocityEngineProperties.setProperty( "resource.loaders", "file, class, jar ,report" );
+            velocityEngineProperties.setProperty( "resource.loader.report.class",
                                                   XDocReportEntryResourceLoader.class.getName() );
-            velocityEngineProperties.setProperty( "report.resource.loader.cache", "true" );
-            velocityEngineProperties.setProperty( "report.resource.loader.modificationCheckInterval", "1" );
+            velocityEngineProperties.setProperty( "resource.loader.report.cache", "true" );
+            velocityEngineProperties.setProperty( "resource.loader.file.modification_check_interval", "1" );
         }
 
         // Set properties to maximize backward compatibility of previous XDoxReports Velocity 1 templates with Velocity 2:

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/VelocityTemplateEngine.java
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/java/fr/opensagres/xdocreport/template/velocity/internal/VelocityTemplateEngine.java
@@ -144,7 +144,7 @@ public class VelocityTemplateEngine
         super.setConfiguration( configuration );
         if ( configuration != null && configuration.escapeXML() )
         {
-            velocityEngineProperties.setProperty( "eventhandler.referenceinsertion.class",
+            velocityEngineProperties.setProperty( "event_handler.reference_insertion.class",
                                                   XDocReportEscapeReference.class.getName() );
         }
 

--- a/template/fr.opensagres.xdocreport.template.velocity/src/main/resources/xdocreport-velocity.properties
+++ b/template/fr.opensagres.xdocreport.template.velocity/src/main/resources/xdocreport-velocity.properties
@@ -24,7 +24,7 @@
 #
 
 #velocimacro.library=${velocity.velocimacro.library}
-#runtime.log.invalid.references=true
+#runtime.log.log_invalid_references=true
 #runtime.log=${velocity.runtime.log}
 #velocimacro.library.autoreload=true
 #parser.pool.size=20
@@ -67,13 +67,13 @@ runtime.log=velocity.log
 # This controls whether invalid references are logged.
 # ----------------------------------------------------------------------------
 
-runtime.log.invalid.references = true
+runtime.log.log_invalid_references = true
 
 # ----------------------------------------------------------------------------
 # T E M P L A T E  E N C O D I N G
 # ----------------------------------------------------------------------------
 
-input.encoding=UTF-8
+resource.default_encoding=UTF-8
 output.encoding=UTF-8
 
 # ----------------------------------------------------------------------------
@@ -87,7 +87,7 @@ output.encoding=UTF-8
 
 directive.foreach.counter.name = velocityCount
 directive.foreach.counter.initial.value = 1
-directive.foreach.maxloops = -1
+directive.foreach.max_loops = -1
 
 directive.foreach.iterator.name = velocityHasNext
 
@@ -118,14 +118,14 @@ directive.if.tostring.nullcheck = true
 # is governed.
 # ----------------------------------------------------------------------------
 
-directive.include.output.errormsg.start = <!-- include error :
-directive.include.output.errormsg.end   =  see error log -->
+directive.include.output_error_start = <!-- include error :
+directive.include.output_error_end   =  see error log -->
 
 # ----------------------------------------------------------------------------
 # P A R S E  P R O P E R T I E S
 # ----------------------------------------------------------------------------
 
-directive.parse.max.depth = 10
+directive.parse.max_depth = 10
 
 # ----------------------------------------------------------------------------
 # S C O P E  P R O P E R T I E S
@@ -138,7 +138,7 @@ directive.parse.max.depth = 10
 # ----------------------------------------------------------------------------
 # template.provide.scope.control = false
 # evaluate.provide.scope.control = false
-foreach.provide.scope.control = true
+context.scope_control.foreach = true
 # macro.provide.scope.control = false
 # define.provide.scope.control = false
 # <bodymacroname>.provide.scope.control = false
@@ -150,16 +150,16 @@ foreach.provide.scope.control = true
 #
 # ----------------------------------------------------------------------------
 
-resource.loader = file
+resource.loaders = file
 
-file.resource.loader.description = Velocity File Resource Loader
-file.resource.loader.class = org.apache.velocity.runtime.resource.loader.FileResourceLoader
-file.resource.loader.path = .
-file.resource.loader.cache = false
-file.resource.loader.modificationCheckInterval = 2
+resource.loader.file.description = Velocity File Resource Loader
+resource.loader.file.class = org.apache.velocity.runtime.resource.loader.FileResourceLoader
+resource.loader.file.path = .
+resource.loader.file.cache = false
+resource.loader.file.modification_check_interval = 2
 
-string.resource.loader.description = Velocity String Resource Loader
-string.resource.loader.class = org.apache.velocity.runtime.resource.loader.StringResourceLoader
+resource.loader.string.description = Velocity String Resource Loader
+resource.loader.string.class = org.apache.velocity.runtime.resource.loader.StringResourceLoader
 
 # ----------------------------------------------------------------------------
 # VELOCIMACRO PROPERTIES
@@ -171,12 +171,12 @@ string.resource.loader.class = org.apache.velocity.runtime.resource.loader.Strin
 # velocimacro.library = VM_global_library.vm
 #velocimacro.library=${velocity.velocimacro.library}
 
-velocimacro.permissions.allow.inline = true
-velocimacro.permissions.allow.inline.to.replace.global = false
-velocimacro.permissions.allow.inline.local.scope = false
+velocimacro.inline.allow = true
+velocimacro.inline.replace_global = false
+velocimacro.inline.local_scope = false
 
 velocimacro.context.localscope = false
-velocimacro.max.depth = 20
+velocimacro.max_depth = 20
 
 # ----------------------------------------------------------------------------
 # VELOCIMACRO STRICT MODE
@@ -194,7 +194,7 @@ velocimacro.arguments.strict = false
 # Defines name of the reference that can be used to render the AST block passed to
 # block macro call as an argument inside a macro.
 # ----------------------------------------------------------------------------
-velocimacro.body.reference=bodyContent
+velocimacro.body_reference=bodyContent
 
 # ----------------------------------------------------------------------------
 # STRICT REFERENCE MODE
@@ -206,7 +206,7 @@ velocimacro.body.reference=bodyContent
 # or if the object is null.  When this property is true then property
 # 'directive.set.null.allowed' is also set to true.
 # ----------------------------------------------------------------------------
-runtime.references.strict = false
+runtime.strict_mode.enable = false
 
 # ----------------------------------------------------------------------------
 # INTERPOLATION
@@ -214,7 +214,7 @@ runtime.references.strict = false
 # turn off and on interpolation of references and directives in string
 # literals.  ON by default :)
 # ----------------------------------------------------------------------------
-runtime.interpolate.string.literals = true
+runtime.interpolate_string_literals = true
 
 
 # ----------------------------------------------------------------------------
@@ -245,7 +245,7 @@ parser.pool.size = 20
 # class property is actually a comma-separated list of classes (which will
 # be called in order).
 # ----------------------------------------------------------------------------
-# eventhandler.referenceinsertion.class =
+# event_handler.reference_insertion.class =
 # eventhandler.nullset.class =
 # eventhandler.methodexception.class =
 # eventhandler.include.class =
@@ -268,7 +268,7 @@ parser.pool.size = 20
 # Allows alternative introspection and all that can of worms brings.
 # ----------------------------------------------------------------------------
 
-runtime.introspector.uberspect = org.apache.velocity.util.introspection.UberspectImpl
+introspector.uberspect.class = org.apache.velocity.util.introspection.UberspectImpl
 
 
 # ----------------------------------------------------------------------------
@@ -290,7 +290,7 @@ introspector.restrict.classes = java.lang.Class, java.lang.ClassLoader, java.lan
 runtime.log.logsystem.class = org.apache.velocity.runtime.log.NullLogChute
 # If you want activate the log comment last line and uncomment the next one
 #runtime.log=${velocity.runtime.log}
-resource.loader=file, class, jar ,report
-report.resource.loader.class=fr.opensagres.xdocreport.template.velocity.cache.XDocReportEntryResourceLoader
-report.resource.loader.cache=true
-report.resource.loader.modificationCheckInterval=1
+resource.loaders=file, class, jar ,report
+resource.loader.report.class=fr.opensagres.xdocreport.template.velocity.cache.XDocReportEntryResourceLoader
+resource.loader.report.cache=true
+resource.loader.file.modification_check_interval=1


### PR DESCRIPTION
The goal of this merge request is to avoid deprecation message from velocity engine like : 
`15:03:18.178 WARN  org.apache.velocity.deprecation - configuration key 'report.resource.loader.modificationCheckInterval' has been deprecated in favor of 'resource.loader.report.modificationCheckInterval'
15:03:18.184 WARN  org.apache.velocity.deprecation - configuration key 'report.resource.loader.cache' has been deprecated in favor of 'resource.loader.report.cache'
15:03:18.184 WARN  org.apache.velocity.deprecation - configuration key 'resource.loader' has been deprecated in favor of 'resource.loaders'
15:03:18.186 WARN  org.apache.velocity.deprecation - configuration key 'report.resource.loader.class' has been deprecated in favor of 'resource.loader.report.class'
15:03:18.186 WARN  org.apache.velocity.deprecation - configuration key 'eventhandler.referenceinsertion.class' has been deprecated in favor of 'event_handler.reference_insertion.class'
15:03:18.189 WARN  org.apache.velocity.deprecation - configuration key 'modificationCheckInterval' has been deprecated in favor of 'modification_check_interval'
`