### PR TITLE
Updated the FreeMarker Dependency from 2.3.20 to 2.3.28

### DIFF
--- a/template/fr.opensagres.xdocreport.template.freemarker/pom.xml
+++ b/template/fr.opensagres.xdocreport.template.freemarker/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.20</version>
+			<version>2.3.28</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This change in version on the FreeMarker Dependency will allow the use of multiple new functionalities.

On the FreeMarker [Download Page](https://freemarker.sourceforge.io/freemarkerdownload.html), it marks the version 2.3.20 as the latest stable version, but as can be seen on the releases on the [Version History Page](https://freemarker.apache.org/docs/app_versions.html) on their Website, that information is not updated.