### PR TITLE
fix(sec): upgrade org.apache.cxf:cxf-bundle-jaxrs to 2.5.5

### DIFF
--- a/sandbox/fr.opensagres.xdocreport.remoting.javaclient/pom.xml
+++ b/sandbox/fr.opensagres.xdocreport.remoting.javaclient/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.5.2</version>
+      <version>2.7.11</version>
       <exclusions>
         <exclusion>
           <artifactId>xmlschema-core</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.cxf:cxf-bundle-jaxrs 2.5.2
- [CVE-2012-3451](https://www.oscs1024.com/hd/CVE-2012-3451)


### What did I do？
Upgrade org.apache.cxf:cxf-bundle-jaxrs from 2.5.2 to 2.5.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS