### PR TITLE
Update to OpenPDF 2.0.0.

### DIFF
--- a/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/pom.xml
+++ b/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.18</version>
+			<version>2.0.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bcmail-jdk14</artifactId>


### PR DESCRIPTION
Update to OpenPDF 2.0.0:

https://github.com/opensagres/xdocreport/issues/635
https://github.com/LibrePDF/OpenPDF/releases/tag/2.0.0