### PR TITLE
Updated to openPDF 2.0.2

### DIFF
--- a/thirdparties-extension/fr.opensagres.odfdom.converter.pdf.openpdf/src/main/java/fr/opensagres/odfdom/converter/pdf/internal/stylable/StylableParagraph.java
+++ b/thirdparties-extension/fr.opensagres.odfdom.converter.pdf.openpdf/src/main/java/fr/opensagres/odfdom/converter/pdf/internal/stylable/StylableParagraph.java
@@ -24,16 +24,11 @@
  */
 package fr.opensagres.odfdom.converter.pdf.internal.stylable;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Element;
 import com.lowagie.text.Font;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.pdf.BaseFont;
-
 import fr.opensagres.odfdom.converter.core.utils.ODFUtils;
 import fr.opensagres.odfdom.converter.pdf.internal.styles.Style;
 import fr.opensagres.odfdom.converter.pdf.internal.styles.StyleBreak;
@@ -41,6 +36,10 @@ import fr.opensagres.odfdom.converter.pdf.internal.styles.StyleLineHeight;
 import fr.opensagres.odfdom.converter.pdf.internal.styles.StyleParagraphProperties;
 import fr.opensagres.odfdom.converter.pdf.internal.styles.StyleTextProperties;
 import fr.opensagres.xdocreport.openpdf.extension.ExtendedParagraph;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * fixes for paragraph pdf conversion by Leszek Piotrowicz <leszekp@safe-mail.net>
@@ -249,9 +248,9 @@ public class StylableParagraph
 
             Chunk lastChunk = (Chunk) elements.get( elements.size() - 1 );
             String localDestination = null;
-            if ( lastChunk.getAttributes() != null )
+            if ( lastChunk.getChunkAttributes() != null )
             {
-                localDestination = (String) lastChunk.getAttributes().get( Chunk.LOCALDESTINATION );
+                localDestination = (String) lastChunk.getChunkAttributes().get( Chunk.LOCALDESTINATION );
             }
             if ( localDestination != null )
             {

--- a/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/pom.xml
+++ b/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/pom.xml
@@ -10,33 +10,7 @@
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.18</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>bcmail-jdk14</artifactId>
-					<groupId>org.bouncycastle</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>bcprov-jdk14</artifactId>
-					<groupId>org.bouncycastle</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>bctsp-jdk14</artifactId>
-					<groupId>org.bouncycastle</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>bouncycastle</groupId>
-					<artifactId>bcprov-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>bouncycastle</groupId>
-					<artifactId>bctsp-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>bouncycastle</groupId>
-					<artifactId>bcmail-jdk14</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<artifactId>bcmail-jdk14</artifactId>

--- a/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/src/main/java/fr/opensagres/xdocreport/openpdf/extension/ExtendedPdfPTable.java
+++ b/thirdparties-extension/fr.opensagres.xdocreport.openpdf.extension/src/main/java/fr/opensagres/xdocreport/openpdf/extension/ExtendedPdfPTable.java
@@ -184,38 +184,38 @@ public class ExtendedPdfPTable
     }
 
     @Override
-    public void addCell( Image image )
+    public PdfPCell addCell( Image image )
     {
         this.empty = false;
-        super.addCell( image );
+        return super.addCell( image );
     }
 
     @Override
-    public void addCell( PdfPCell cell )
+    public PdfPCell addCell( PdfPCell cell )
     {
         this.empty = false;
-        super.addCell( cell );
+        return super.addCell( cell );
     }
 
     @Override
-    public void addCell( PdfPTable table )
+    public PdfPCell addCell( PdfPTable table )
     {
         this.empty = false;
-        super.addCell( table );
+        return super.addCell( table );
     }
 
     @Override
-    public void addCell( Phrase phrase )
+    public PdfPCell addCell( Phrase phrase )
     {
         this.empty = false;
-        super.addCell( phrase );
+        return super.addCell( phrase );
     }
 
     @Override
-    public void addCell( String text )
+    public PdfPCell addCell( String text )
     {
         this.empty = false;
-        super.addCell( text );
+        return super.addCell( text );
     }
 
     public boolean isEmpty()


### PR DESCRIPTION
Update to OpenPDF 2.0.2:

https://github.com/opensagres/xdocreport/issues/635


OpenPDF require Java 17 or later from version 2.0.0 and later. Before the requirement was java 8.
https://github.com/LibrePDF/OpenPDF/releases/tag/2.0.2.

I removed the exclusions on bouncycastle. These exclusions are no longer dependencies of openpdf. Also the bouncycastle dependencies that are currently dependencies of openpdf are all optional.