### PR TITLE
Fix invalid paragraph nesting inside ODT headers causing XML parsing errors

### DIFF
--- a/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/textstyling/ODTDocumentHandler.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/main/java/fr/opensagres/xdocreport/document/odt/textstyling/ODTDocumentHandler.java
@@ -257,6 +257,11 @@ public class ODTDocumentHandler
         throws IOException
     {
 
+        if ( insideHeader )
+        {
+            return;
+        }
+
         if ( ( paragraphWasInserted && paragraphsStack.isEmpty() ) || closeHeader )
         {
             internalStartParagraph( false, (String) null );


### PR DESCRIPTION
## Problem

When generating ODT documents with styled text (bold, italic, underline, etc.) inside headers, the `ODTDocumentHandler` incorrectly creates paragraph elements (`<text:p>`) inside header elements (`<text:h>`). This violates the ODT specification where both headers and paragraphs are block-level elements that cannot be nested.

### Current Invalid Output
```xml
<text:h text:style-name="Heading_20_1" text:outline-level="1">
    <text:p><text:span text:style-name="XDocReport_Bold">Bold Header Text</text:span>
</text:h>
<!-- Missing </text:p> closing tag -->
```

### Excpected Valid Output
```xml
<text:h text:style-name="Heading_20_1" text:outline-level="1">
    <text:span text:style-name="XDocReport_Bold">Bold Header Text</text:span>
</text:h>
```

### Errors Caused
#### **SAX Parser Exception when parsing the generated ODT:**
```
org.xml.sax.SAXParseException: The element type "text:p" must be terminated by the matching end-tag "</text:p>"
```

#### **ClassCastException during PDF conversion:**
```
java.lang.ClassCastException: Insertion of illegal Element: 12
at com.lowagie.text.Phrase.add(Phrase.java:301)
```

### Solution
**Modified startParagraphIfNeeded in ODTDocumentHandler.java:**

* Added check for insideHeader flag
* Prevents paragraph creation when inside header elements

### Fixes #685 